### PR TITLE
Fix includes for lwIP

### DIFF
--- a/src/routes.c
+++ b/src/routes.c
@@ -1884,10 +1884,14 @@ const char *wolfsentry_family_ntop(wolfsentry_family_t family) {
 
 #ifndef WOLFSENTRY_NO_STDIO
 
+#ifndef WOLFSENTRY_LWIP
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
-
+#else
+#include <lwip/inet.h>
+#include <lwip/sockets.h>
+#endif
 #ifdef WOLFSENTRY_PROTOCOL_NAMES
 #include <netdb.h>
 #endif

--- a/wolfsentry/wolfsentry_errcodes.h
+++ b/wolfsentry/wolfsentry_errcodes.h
@@ -116,7 +116,7 @@ enum wolfsentry_source_id {
 };
 
 #ifdef WOLFSENTRY_ERROR_STRINGS
-WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_user_source_string_set(enumint_t wolfsentry_source_id, const char *source_string);
+WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_user_source_string_set(enum wolfsentry_source_id wolfsentry_source_id, const char *source_string);
 #define WOLFSENTRY_REGISTER_SOURCE() wolfsentry_user_source_string_set(WOLFSENTRY_SOURCE_ID,__FILE__)
 #endif
 


### PR DESCRIPTION
In Linux this wasn't spotted as the normal POSIX socket headers are
provided, but lwIP's include structure is a little different. This patch
adds an ifdef called WOLFSENTRY_LWIP which changes the headers included.

Note that you will need to set WOLFSENTRY_NO_PROTOCOL_NAMES if you only
have lwIP. I haven't hard-set this for WOLFSENTRY_LWIP as you may have
the required POSIX socket headers too.