### PR TITLE
Fixes to the Linux LWIP example

### DIFF
--- a/examples/Linux-LWIP/README.md
+++ b/examples/Linux-LWIP/README.md
@@ -14,7 +14,7 @@ This test is designed to be run on Linux or macOS, but should work on Windows as
 The following command will build the test echo server and start this up along with three testing nodes:
 
 ```sh
-sudo docker-compose -f docker-compose.yml up -d
+sudo docker-compose -f docker-compose.yml up --build -d
 ```
 
 You can follow the logs for the echo server using:
@@ -56,7 +56,7 @@ The sentry test is configured to allow this node to ping the echoserver node, bu
 * IP address: 172.20.20.20
 * MAC address: de:c0:de:03:02:02
 
-The sentry test is configured to block this node pinging the echoserver node, but the TCP connection is not accepted during handshake.
+The sentry test is configured to block this node pinging the echoserver node, but the TCP connection is accepted during handshake.
 
 #### Tester 3
 
@@ -87,18 +87,11 @@ Tested node 2 will work and whatever you enter into the netcat terminal will be 
 
 ## Shutting down
 
-You can stop the nodes by running the following:
+You can stop and clean up the nodes by running the following, this will also remove the virtual network:
 
 ```sh
-sudo docker-compose -f docker-compose.yml stop
+sudo docker-compose -f docker-compose.yml down
 ```
-
-Then remove them using:
-
-```sh
-sudo docker-compose -f docker-compose.yml rm -f
-```
-
 
 ## Notes
 

--- a/examples/Linux-LWIP/echo.c
+++ b/examples/Linux-LWIP/echo.c
@@ -7,6 +7,7 @@
 #include "echo.h"
 #include "sentry.h"
 #include "lwip/tcp.h"
+#include "lwip/prot/tcp.h"
 
 #include <stdio.h>
 #include <stdarg.h>
@@ -15,14 +16,13 @@
 #include <time.h>
 
 /* Called by echo_msgrecv() when it effectively gets an EOF */
-
 static void echo_msgclose(struct tcp_pcb *pcb)
 {
-    printf("Closing connection\n");
+    printf("Closing connection from: %s\n", ipaddr_ntoa(&(pcb->remote_ip)));
     fflush(stdout);
     /* Tell sentry_action() that this is a disconnect event which decrements
      * the connection count */
-    sentry_action(pcb, SENTRY_ACTION_DISCONNECT);
+    sentry_action(&pcb->local_ip, &pcb->remote_ip, pcb->local_port, pcb->remote_port, SENTRY_ACTION_DISCONNECT);
 
     /* Remove all the callbacks and shutdown the connection */
     tcp_arg(pcb, NULL);
@@ -71,6 +71,10 @@ static err_t echo_msgaccept(void *arg, struct tcp_pcb *pcb, err_t err)
     printf("Connect from: %s port: %d\n", ipaddr_ntoa(&(pcb->remote_ip)), pcb->remote_port);
     fflush(stdout);
 
+    /* The below is an alternative hook to check for incoming connections. The
+     * down side of this is that it will only trigger after the initial SYN/ACK
+     */
+    /*
     if (sentry_action(pcb, SENTRY_ACTION_CONNECT) != 0)
     {
         printf("Sentry rejected connection\n");
@@ -78,6 +82,7 @@ static err_t echo_msgaccept(void *arg, struct tcp_pcb *pcb, err_t err)
         tcp_abort(pcb);
         return ERR_ABRT;
     }
+    */
 
     /* Set an arbitrary pointer for callbacks. We don't use this right now */
     //tcp_arg(pcb, esm);
@@ -109,4 +114,32 @@ int echo_init(void)
     tcp_accept(pcb, echo_msgaccept);
 
     return 0;
+}
+
+/* Hook to incoming TCP packet. We catch incoming connections here because the
+ * tcp_accept() hook is triggered after the first ACK
+ */
+int sentry_tcp_inpkt(struct tcp_pcb *pcb, struct tcp_hdr *hdr, uint16_t optlen,
+        uint16_t opt1len, uint8_t *opt2, struct pbuf *p)
+{
+    /* First incoming packet is in a LISTEN state */
+    if (pcb->state == LISTEN)
+    {
+        /* The tcp_pcb struct does is not filled in with the IP/port details
+         * yet, that happens immediately after this callback, so we get these
+         * details from other sources. The same sources that are about to fill
+         * in the details into the sruct */
+        printf("Incomming connection from: %s\n",
+                ipaddr_ntoa(ip_current_src_addr()));
+        fflush(stdout);
+        if (sentry_action(ip_current_dest_addr(), ip_current_src_addr(),
+                    pcb->local_port, hdr->src , SENTRY_ACTION_CONNECT) != 0)
+        {
+            printf("Sentry rejected connection from: %s\n",
+                    ipaddr_ntoa(ip_current_src_addr()));
+            fflush(stdout);
+            return ERR_ABRT;
+        }
+    }
+    return ERR_OK;
 }

--- a/examples/Linux-LWIP/echo.h
+++ b/examples/Linux-LWIP/echo.h
@@ -3,6 +3,13 @@
 #ifndef __ECHO_H__
 #define __ECHO_H__
 
+#include <stdint.h>
+
+struct pbuf;
+struct tcp_pcb;
+struct tcp_hdr;
+
 int echo_init(void);
+int sentry_tcp_inpkt(struct tcp_pcb *pcb, struct tcp_hdr *hdr, uint16_t optlen, uint16_t opt1len, uint8_t *opt2, struct pbuf *p);
 
 #endif

--- a/examples/Linux-LWIP/lwip-include/lwipopts.h
+++ b/examples/Linux-LWIP/lwip-include/lwipopts.h
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+/* Include echo.h to give us sentry_tcp_inpkt */
+#include "../echo.h"
+
 #define TCP_MSS                         1500
 #define TCP_WND                         65535
 #define NO_SYS                          0
@@ -33,3 +36,5 @@
 
 #define LWIP_CHECKSUM_CTRL_PER_NETIF    1
 
+/* Define a callback which will trigger on TCP packet input */
+#define LWIP_HOOK_TCP_INPACKET_PCB sentry_tcp_inpkt

--- a/examples/Linux-LWIP/main.c
+++ b/examples/Linux-LWIP/main.c
@@ -44,15 +44,21 @@ static err_t filter_input(struct pbuf *p, struct netif *inp)
 {
     /* Start of payload will have an Ethernet header */
     struct eth_hdr *ethhdr = (struct eth_hdr *)p->payload;
+    struct eth_addr *ethaddr = &ethhdr->src;
+
     /* "src" contains the source hardware address from the packet */
-    if (sentry_action_mac(&ethhdr->src) != 0)
+    if (sentry_action_mac(ethaddr) != 0)
     {
-        printf("Sentry rejected MAC address\n");
+        printf("Sentry rejected MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
+                ethaddr->addr[0], ethaddr->addr[1], ethaddr->addr[2],
+                ethaddr->addr[3], ethaddr->addr[4], ethaddr->addr[5]);
         fflush(stdout);
         /* Basically drop the packet */
         return ERR_ABRT;
     }
-    printf("Sentry accepted MAC address\n");
+    printf("Sentry accepted MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
+            ethaddr->addr[0], ethaddr->addr[1], ethaddr->addr[2],
+            ethaddr->addr[3], ethaddr->addr[4], ethaddr->addr[5]);
     fflush(stdout);
     /* We passed the MAC filter, so pass the packet to the regular internal
      * lwIP input callback */

--- a/examples/Linux-LWIP/ping.c
+++ b/examples/Linux-LWIP/ping.c
@@ -7,8 +7,6 @@
 #include "lwip/raw.h"
 #include "lwip/icmp.h"
 
-static struct raw_pcb *ping_pcb;
-
 /* ICMP message received. Return 0 to let lwIP process it and 1 to eat the
  * packet */
 static u8_t ping_recv(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *addr)
@@ -27,13 +25,13 @@ static u8_t ping_recv(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_a
       {
           /* RAW recv needs to free if not returning 0 */
           pbuf_free(p);
-          printf("Ping rejected\n");
+          printf("Ping rejected from %s\n", ipaddr_ntoa(addr));
           fflush(stdout);
           return 1;
       }
   }
 
-  printf("Ping accepted\n");
+  printf("Ping accepted from %s\n", ipaddr_ntoa(addr));
   fflush(stdout);
   return 0;
 }
@@ -41,6 +39,7 @@ static u8_t ping_recv(void *arg, struct raw_pcb *pcb, struct pbuf *p, const ip_a
 /* Initialise the ICMP hooks */
 int ping_init(void)
 {
+  struct raw_pcb *ping_pcb;
   /* Create a new listener instance for ICMP messages */
   ping_pcb = raw_new(IP_PROTO_ICMP);
   LWIP_ASSERT("ping_pcb != NULL", ping_pcb != NULL);

--- a/examples/Linux-LWIP/sentry.c
+++ b/examples/Linux-LWIP/sentry.c
@@ -169,7 +169,7 @@ int sentry_init()
 
 /* Check a TCP connection with wolfSentry. This is called for connect and
  * disconnect so wolfSentry can count the simultaneous connections */
-int sentry_action(struct tcp_pcb *pcb, sentry_action_type action)
+int sentry_action(ip_addr_t *local_ip, ip_addr_t *remote_ip, in_port_t local_port, in_port_t remote_port, sentry_action_type action)
 {
     wolfsentry_errcode_t ret;
     wolfsentry_action_res_t action_results;
@@ -178,8 +178,8 @@ int sentry_action(struct tcp_pcb *pcb, sentry_action_type action)
         struct wolfsentry_sockaddr sa;
         byte addr_buf[4];
     } remote, local;
-    u32_t remoteip = pcb->remote_ip.addr;
-    u32_t localip = pcb->local_ip.addr;
+    u32_t remoteip = remote_ip->addr;
+    u32_t localip = local_ip->addr;
 
     /* Connect will increment the connection count in wolfSentry, disconnect
      * will decrement it */
@@ -198,7 +198,7 @@ int sentry_action(struct tcp_pcb *pcb, sentry_action_type action)
     /* Setup sockaddr information to send to wolfSentry */
     remote.sa.sa_family = WOLFSENTRY_AF_INET;
     remote.sa.sa_proto = IPPROTO_TCP;
-    remote.sa.sa_port = pcb->remote_port;
+    remote.sa.sa_port = remote_port;
     /* Essentially a prefix size, wolfSentry uses the lesser of this and the
      * rule in JSON as to how much of the IP address to compare */
     remote.sa.addr_len = 32; // prefix size
@@ -207,7 +207,7 @@ int sentry_action(struct tcp_pcb *pcb, sentry_action_type action)
 
     local.sa.sa_family = WOLFSENTRY_AF_INET;
     local.sa.sa_proto = IPPROTO_TCP;
-    local.sa.sa_port = pcb->local_port;
+    local.sa.sa_port = local_port;
     local.sa.addr_len = 32;
     local.sa.interface = 0;
     memcpy(local.sa.addr, &localip, 4);

--- a/examples/Linux-LWIP/sentry.h
+++ b/examples/Linux-LWIP/sentry.h
@@ -3,6 +3,7 @@
 #ifndef __SENTRY_H__
 #define __SENTRY_H__
 #include "lwip/tcp.h"
+#include "lwip/sockets.h"
 #include <netif/etharp.h>
 #include <stdbool.h>
 
@@ -13,7 +14,7 @@ typedef enum {
 } sentry_action_type;
 
 int sentry_init(void);
-int sentry_action(struct tcp_pcb *pcb, sentry_action_type action);
+int sentry_action(ip_addr_t *local_ip, ip_addr_t *remote_ip, in_port_t local_port, in_port_t remote_port, sentry_action_type action);
 int sentry_action_ping(const ip_addr_t *addr, u8_t type);
 int sentry_action_mac(struct eth_addr *addr);
 #endif


### PR DESCRIPTION
README:
* Add --build to docker-compose to force rebuild if the source changes
* Fix a typo
* Switched the docker-compose "stop" to "down" which brings down
  everything including network and cleans up

TCP Echo:
* Add hook to TCP packet input, use this to capture new connections so
  that we can capture before the first SYN/ACK is complete

ICMP Ping:
* Add IP address details to output
* Remove global that doesn't need to be global

MAC address:
* Add MAC address details to output