### PR TITLE
-DWOLFSENTRY_LOCK_ERROR_CHECKING -DWOLFSENTRY_LOCK_DEBUGGING

### DIFF
--- a/Makefile.analyzers
+++ b/Makefile.analyzers
@@ -84,7 +84,7 @@ sanitize: TEST_ENV+=ASAN_OPTIONS='detect_invalid_pointer_pairs=2:halt_on_error=1
 sanitize: test
 
 .PHONY: sanitize-thread
-sanitize-thread: CFLAGS+=-fsanitize=thread
+sanitize-thread: CFLAGS+=-fsanitize=thread -DWOLFSENTRY_LOCK_ERROR_CHECKING -DWOLFSENTRY_LOCK_DEBUGGING
 sanitize-thread: LDFLAGS+=-fsanitize=thread
 sanitize-thread: TEST_ENV+=ASAN_OPTIONS='halt_on_error=1'
 sanitize-thread: test
@@ -237,6 +237,13 @@ dynamic-build-test:
 	@echo '$(UNITTEST_LIST_SHARED) passed.'
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP=dynamic-build-test clean
 
+.PHONY: lock-error-checking-test
+lock-error-checking-test:
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP=lock-error-checking-builds clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP=lock-error-checking-builds EXTRA_CFLAGS+='-DWOLFSENTRY_LOCK_ERROR_CHECKING' test
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP=lock-error-checking-builds clean
+	@echo "lock-error-checking test passed."
+
 
 .PHONY: dist-check
 dist-check:
@@ -245,7 +252,7 @@ dist-check:
 	@echo $@ 'passed.'
 
 .PHONY: check
-check: analyze-all dynamic-build-test c99-test m32-test singlethreaded-test no-json-test no-json-dom-test no-error-strings-test no-protocol-names-test no-stdio-test minimal-build-test dist-check
+check: analyze-all dynamic-build-test c99-test m32-test singlethreaded-test no-json-test no-json-dom-test no-error-strings-test no-protocol-names-test no-stdio-test minimal-build-test dist-check lock-error-checking-test
 	@echo "all checks passed."
 
 # recipe to run the pre-push hook on the commit head, without actually pushing:

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -18,9 +18,12 @@ cd "$WORKDIR" || exit $?
 
 while read local_ref local_oid remote_ref remote_oid
 do
-	git checkout -q "$local_oid" || exit $?
-	echo "make --quiet -j check for ${local_ref} at ${local_oid} ..."
-	make --quiet -j check || exit $?
+    if [ "$local_ref" = "(delete)" ]; then
+	continue
+    fi
+    git checkout -q "$local_oid" || exit $?
+    echo "make --quiet -j check for ${local_ref} at ${local_oid} ..."
+    make --quiet -j check || exit $?
 done
 
 exit 0

--- a/src/wolfsentry_ll.h
+++ b/src/wolfsentry_ll.h
@@ -60,13 +60,17 @@ static inline void wolfsentry_list_ent_append(struct wolfsentry_list_header *lis
 
 static inline void wolfsentry_list_ent_insert_after(struct wolfsentry_list_header *list, struct wolfsentry_list_ent_header *point_ent, struct wolfsentry_list_ent_header *new_ent) {
     if (point_ent == NULL) {
-        wolfsentry_list_ent_prepend(list, new_ent);
+        /* in principle, we should _prepend() here, but in practice, iteration
+         * code patterns make it far more convenient to append.
+         */
+        wolfsentry_list_ent_append(list, new_ent);
         return;
     }
     new_ent->prev = point_ent;
-    if (point_ent->next)
+    if (point_ent->next) {
         new_ent->next = point_ent->next;
-    else
+        new_ent->next->prev = new_ent;
+    } else
         list->tail = new_ent;
     point_ent->next = new_ent;
 }

--- a/wolfsentry/wolfsentry_util.h
+++ b/wolfsentry/wolfsentry_util.h
@@ -64,6 +64,8 @@
 #define WOLFSENTRY_ATOMIC_DECREMENT_BY_ONE(i) WOLFSENTRY_ATOMIC_DECREMENT(i, 1)
 #define WOLFSENTRY_ATOMIC_POSTINCREMENT(i, x) __atomic_fetch_add(&(i),x,__ATOMIC_SEQ_CST)
 #define WOLFSENTRY_ATOMIC_POSTDECREMENT(i, x) __atomic_fetch_sub(&(i),x,__ATOMIC_SEQ_CST)
+#define WOLFSENTRY_ATOMIC_STORE(i, x) __atomic_store_n(&(i), x, __ATOMIC_RELEASE)
+#define WOLFSENTRY_ATOMIC_LOAD(i) __atomic_load_n(&(i), __ATOMIC_CONSUME)
 
 #define WOLFSENTRY_ATOMIC_UPDATE(i, set_i, clear_i, pre_i, post_i)      \
 do {                                                                    \


### PR DESCRIPTION
add lock error checking gated on `WOLFSENTRY_LOCK_ERROR_CHECKING` at build and `WOLFSENTRY_INIT_FLAG_LOCK_ERROR_CHECKING`/`WOLFSENTRY_LOCK_FLAG_ERROR_CHECKING` at runtime;

add `wolfsentry_init_flags_t` and `wolfsentry_init_ex()` to use it;

add `wolfsentry_lock_flags_t` and accept it as final arg to `wolfsentry_lock_init()` and `wolfsentry_lock_alloc()` in place of the previous `int pshared` and add `wolfsentry_context` pointer as new first arg to `wolfsentry_lock_init()`;

implement lock self-consistency checks gated on `-DWOLFSENTRY_LOCK_DEBUGGING`, and in Makefile.analyzers, build sanitize-thread `-DWOLFSENTRY_LOCK_ERROR_CHECKING -DWOLFSENTRY_LOCK_DEBUGGING`;

add `lock-error-checking-test` to Makefile.analyzers;

add `WOLFSENTRY_ATOMIC_STORE()` and `WOLFSENTRY_ATOMIC_LOAD()` macros.