### PR TITLE
20230403-fixes-for-1v2v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,7 +424,6 @@ endif
 .PHONY: com-bundle
 com-bundle:
 	@if [[ -z "$(RELEASE)" ]]; then echo "Can't make commercial bundle -- version isn't known."; exit 1; fi
-	@if [[ ! -d "$(SRC_TOP)/../scripts/license_replace" ]]; then echo "license_replace script directory not found."; exit 1; fi
 ifndef VERY_QUIET
 	@echo "generating com-bundle $${PWD}/wolfsentry-$(RELEASE)-commercial.7z ..."
 endif

--- a/src/wolfsentry_internal.h
+++ b/src/wolfsentry_internal.h
@@ -348,6 +348,7 @@ struct wolfsentry_route_table {
     struct wolfsentry_event *default_event; /* used as the parent_event by wolfsentry_route_dispatch() for a static route match with a null parent_event. */
     struct wolfsentry_route *fallthrough_route; /* used as the rule_route when no rule_route is matched or inserted. */
     wolfsentry_action_res_t default_policy;
+    wolfsentry_priority_t highest_priority_route_in_table;
 };
 
 struct wolfsentry_kv_pair_internal {

--- a/src/wolfsentry_util.c
+++ b/src/wolfsentry_util.c
@@ -327,9 +327,9 @@ _Pragma("GCC diagnostic push");
 _Pragma("GCC diagnostic ignored \"-Wframe-address\"");
 
 #ifdef WOLFSENTRY_CALL_DEPTH_RETURNS_STRING
-WOLFSENTRY_LOCAL const char *_wolfsentry_call_depth(void)
+WOLFSENTRY_API const char *_wolfsentry_call_depth(void)
 #else
-WOLFSENTRY_LOCAL unsigned int _wolfsentry_call_depth(void)
+WOLFSENTRY_API unsigned int _wolfsentry_call_depth(void)
 #endif
 {
     unsigned int i;

--- a/wolfsentry/wolfsentry.h
+++ b/wolfsentry/wolfsentry.h
@@ -23,9 +23,9 @@
 #ifndef WOLFSENTRY_H
 #define WOLFSENTRY_H
 
-#define WOLFSENTRY_VERSION_MAJOR 2
-#define WOLFSENTRY_VERSION_MINOR 1
-#define WOLFSENTRY_VERSION_TINY 0
+#define WOLFSENTRY_VERSION_MAJOR 1
+#define WOLFSENTRY_VERSION_MINOR 2
+#define WOLFSENTRY_VERSION_TINY 1
 #define WOLFSENTRY_VERSION_ENCODE(major, minor, tiny) (((major) << 16U) | ((minor) << 8U) | (tiny))
 #define WOLFSENTRY_VERSION WOLFSENTRY_VERSION_ENCODE(WOLFSENTRY_VERSION_MAJOR, WOLFSENTRY_VERSION_MINOR, WOLFSENTRY_VERSION_TINY)
 #define WOLFSENTRY_VERSION_GT(major, minor, tiny) (WOLFSENTRY_VERSION > WOLFSENTRY_VERSION_ENCODE(major, minor, tiny))
@@ -376,11 +376,11 @@ typedef enum {
     WOLFSENTRY_ROUTE_FLAG_SA_REMOTE_ADDR_WILDCARD        = 1U<<1U,
     WOLFSENTRY_ROUTE_FLAG_SA_PROTO_WILDCARD              = 1U<<2U,
     WOLFSENTRY_ROUTE_FLAG_SA_LOCAL_PORT_WILDCARD         = 1U<<3U,
-    WOLFSENTRY_ROUTE_FLAG_PARENT_EVENT_WILDCARD          = 1U<<4U,
-    WOLFSENTRY_ROUTE_FLAG_SA_LOCAL_ADDR_WILDCARD         = 1U<<5U,
-    WOLFSENTRY_ROUTE_FLAG_SA_REMOTE_PORT_WILDCARD        = 1U<<6U,
-    WOLFSENTRY_ROUTE_FLAG_REMOTE_INTERFACE_WILDCARD      = 1U<<7U,
-    WOLFSENTRY_ROUTE_FLAG_LOCAL_INTERFACE_WILDCARD       = 1U<<8U,
+    WOLFSENTRY_ROUTE_FLAG_SA_LOCAL_ADDR_WILDCARD         = 1U<<4U,
+    WOLFSENTRY_ROUTE_FLAG_SA_REMOTE_PORT_WILDCARD        = 1U<<5U,
+    WOLFSENTRY_ROUTE_FLAG_REMOTE_INTERFACE_WILDCARD      = 1U<<6U,
+    WOLFSENTRY_ROUTE_FLAG_LOCAL_INTERFACE_WILDCARD       = 1U<<7U,
+    WOLFSENTRY_ROUTE_FLAG_PARENT_EVENT_WILDCARD          = 1U<<8U,
     WOLFSENTRY_ROUTE_FLAG_TCPLIKE_PORT_NUMBERS           = 1U<<9U,
     WOLFSENTRY_ROUTE_FLAG_DIRECTION_IN                   = 1U<<10U,
     WOLFSENTRY_ROUTE_FLAG_DIRECTION_OUT                  = 1U<<11U,
@@ -404,7 +404,8 @@ typedef enum {
     WOLFSENTRY_ROUTE_FLAG_PORT_RESET                     = 1U<<20U
 } wolfsentry_route_flags_t;
 
-#define WOLFSENTRY_ROUTE_WILDCARD_FLAGS ((wolfsentry_route_flags_t)WOLFSENTRY_ROUTE_FLAG_TCPLIKE_PORT_NUMBERS - 1U)
+/* note, _PARENT_EVENT_WILDCARD is excluded because it isn't an intrinsic attribute of network/bus traffic. */
+#define WOLFSENTRY_ROUTE_WILDCARD_FLAGS ((wolfsentry_route_flags_t)WOLFSENTRY_ROUTE_FLAG_PARENT_EVENT_WILDCARD - 1U)
 
 #define WOLFSENTRY_ROUTE_IMMUTABLE_FLAGS ((wolfsentry_route_flags_t)WOLFSENTRY_ROUTE_FLAG_IN_TABLE - 1U)
 
@@ -1024,6 +1025,7 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_route_format_address(
     int *buflen);
 
 #ifndef WOLFSENTRY_NO_STDIO
+WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_route_render_flags(wolfsentry_route_flags_t flags, FILE *f);
 WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_route_render(WOLFSENTRY_CONTEXT_ARGS_IN, const struct wolfsentry_route *r, FILE *f);
 WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_route_exports_render(WOLFSENTRY_CONTEXT_ARGS_IN, const struct wolfsentry_route_exports *r, FILE *f);
 #endif

--- a/wolfsentry/wolfsentry_errcodes.h
+++ b/wolfsentry/wolfsentry_errcodes.h
@@ -88,11 +88,11 @@ typedef int32_t wolfsentry_errcode_t;
     #define WOLFSENTRY_SUCCESS_RETURN(x) WOLFSENTRY_ERROR_RETURN_1(WOLFSENTRY_SUCCESS_ID_ ## x)
     #if defined(WOLFSENTRY_ERROR_STRINGS) && defined(__GNUC__) && !defined(__STRICT_ANSI__)
         #ifdef WOLFSENTRY_CALL_DEPTH_RETURNS_STRING
-        extern const char *_wolfsentry_call_depth(void);
+        WOLFSENTRY_API const char *_wolfsentry_call_depth(void);
         #define _INDENT_FMT "%s"
         #define _INDENT_ARGS _wolfsentry_call_depth()
         #else
-        extern unsigned int _wolfsentry_call_depth(void);
+        WOLFSENTRY_API unsigned int _wolfsentry_call_depth(void);
         #define _INDENT_FMT "%*s"
         #define _INDENT_ARGS _wolfsentry_call_depth(), ""
         #endif


### PR DESCRIPTION
`src/lwip/packet_filter_glue.c`:

  * remove several inappropriate wildcard flags on queries, particularly `_SA_LOCAL_PORT_WILDCARD` for `FILT_PORT_UNREACHABLE` and `*_INTERFACE_WILDCARD` for `FILT_BINDING`/`FILT_LISTENING`/`FILT_STOP_LISTENING` and when `event->netif` is null;

  * check `laddr` and `raddr` for nullness, and if null, set all-zeros address;

  * in `wolfsentry_install_lwip_filter_*_call()`, when supplied mask is zero, call `ethernet_filter_mask()` and `ethernet_filter_arg()` with zero too, to fully flush residual callback state;

  * add support in the `WOLFSENTRY_DEBUG_LWIP` code paths for collecting and rendering the `match_id` and `inexact_matches` from `wolfsentry_route_event_dispatch_with_inited_result()`;

`wolfsentry/wolfsentry.h`: update version to 1.2.1 (fixes botched 1.2.0 version fields); shift `WOLFSENTRY_ROUTE_FLAG_PARENT_EVENT_WILDCARD` to end of wildcard bits to keep rest of bits contiguous; exclude `_PARENT_EVENT_WILDCARD` from `WOLFSENTRY_ROUTE_WILDCARD_FLAGS`;

`src/routes.c`:

  * add `wolfsentry_route_render_flags()`, and use it in `wolfsentry_route_render()` and `wolfsentry_route_exports_render()`;

  * `addr_prefix_match_size()`: match on whole bytes as much as possible, for efficiency;

  * `wolfsentry_route_key_cmp_1()`: skip flag comparison when `match_wildcards_p`, and refactor event priority comparison and move it to occur right before event label comparison;

  * `wolfsentry_route_init()`, `wolfsentry_route_new()`, and `wolfsentry_route_insert_1()`: zero out wildcard fields at insert time, rather than at init time;

  * add `wolfsentry_route_table.highest_priority_route_in_table`, and maintain it in `wolfsentry_route_table_init()`, `wolfsentry_route_insert_1()`, and `wolfsentry_route_delete_0()`;

  * `wolfsentry_route_lookup_0()`:

    * correctly invert `target_route->flags` bits for contiguity test;

    * refactor early exact match logic for clarity and correctness;

    * refactor main search loop to always return a highest-priority match, with null events having zero (highest) priority, and ties broken using `compare_match_exactness()`;

    * add `DEBUG_ROUTE_LOOKUP` code;

`Makefile`: remove frivolous check for `../scripts/license_replace`.
