### PR TITLE
20230419-no-flush-fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,9 +271,9 @@ ifneq "$(NO_JSON)" "1"
     UNITTEST_LIST += test_json
     ifneq "$(NO_JSON_DOM)" "1"
         UNITTEST_LIST += $(UNITTEST_LIST_JSON_DOM_EXTRAS)
-        TEST_JSON_CFLAGS:=-DTEST_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config.json\" -DTEST_NUMERIC_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config-numeric.json\"
+        TEST_JSON_CFLAGS:=-DTEST_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config.json\" -DEXTRA_TEST_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/extra-test-config.json\" -DTEST_NUMERIC_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config-numeric.json\"
     else
-        TEST_JSON_CFLAGS:=-DTEST_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config-no-dom.json\" -DTEST_NUMERIC_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config-numeric.json\"
+        TEST_JSON_CFLAGS:=-DTEST_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config-no-dom.json\" -DEXTRA_TEST_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/extra-test-config.json\" -DTEST_NUMERIC_JSON_CONFIG_PATH=\"$(SRC_TOP)/tests/test-config-numeric.json\"
     endif
     $(BUILD_TOP)/tests/test_json: override CFLAGS+=$(TEST_JSON_CFLAGS)
 endif

--- a/src/routes.c
+++ b/src/routes.c
@@ -2936,21 +2936,13 @@ WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_route_table_clone_header(
     }
 
     if (((struct wolfsentry_route_table *)src_table)->fallthrough_route != NULL) {
-        struct wolfsentry_event *fallthrough_route;
         if (((struct wolfsentry_route_table *)dest_table)->fallthrough_route != NULL) {
             WOLFSENTRY_WARN_ON_FAILURE(wolfsentry_route_drop_reference_1(
                                            WOLFSENTRY_CONTEXT_ARGS_OUT_EX(dest_context),
                                            ((struct wolfsentry_route_table *)dest_table)->fallthrough_route, NULL /* action_results */));
-            ((struct wolfsentry_route_table *)dest_table)->fallthrough_route = NULL;
         }
-        if ((ret = wolfsentry_table_ent_get_by_id(
-                 dest_context,
-#ifdef WOLFSENTRY_THREADSAFE
-                 thread,
-#endif
-                 ((struct wolfsentry_route_table *)src_table)->fallthrough_route->header.id, (struct wolfsentry_table_ent_header **)&fallthrough_route)) < 0)
-            WOLFSENTRY_ERROR_RERETURN(ret);
-        WOLFSENTRY_REFCOUNT_INCREMENT(fallthrough_route->header.refcount, ret);
+        ((struct wolfsentry_route_table *)dest_table)->fallthrough_route = ((struct wolfsentry_route_table *)src_table)->fallthrough_route;
+        WOLFSENTRY_REFCOUNT_INCREMENT(((struct wolfsentry_route_table *)dest_table)->fallthrough_route->header.refcount, ret);
         WOLFSENTRY_RERETURN_IF_ERROR(ret);
     }
 

--- a/src/wolfsentry_internal.c
+++ b/src/wolfsentry_internal.c
@@ -170,6 +170,7 @@ WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_table_clone(
         if ((ret = clone_fn(WOLFSENTRY_CONTEXT_ARGS_OUT, i, dest_context, &new, flags)) < 0)
             goto out;
         new->parent_table = dest_table;
+        new->prev = prev;
         if (prev)
             prev->next = new;
         else
@@ -524,7 +525,6 @@ WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_table_free_ents(WOLFSENTRY_CONT
         ret = wolfsentry_table_ent_delete_by_id_1(WOLFSENTRY_CONTEXT_ARGS_OUT, i);
         WOLFSENTRY_RERETURN_IF_ERROR(ret);
         table->free_fn(WOLFSENTRY_CONTEXT_ARGS_OUT, i, NULL /* action_results */);
-        WOLFSENTRY_RERETURN_IF_ERROR(ret);
         i = next;
     }
     WOLFSENTRY_RETURN_OK;

--- a/src/wolfsentry_util.c
+++ b/src/wolfsentry_util.c
@@ -3624,8 +3624,6 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_context_clone(
     wolfsentry_errcode_t ret;
 
 #ifdef WOLFSENTRY_THREADSAFE
-    int clone_is_locked = 0;
-
     WOLFSENTRY_SHARED_OR_RETURN();
 
     if ((ret = wolfsentry_context_alloc_1(&wolfsentry->hpi, thread, clone, wolfsentry->lock.flags)) < 0)
@@ -3633,9 +3631,6 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_context_clone(
 
     if ((ret = wolfsentry_context_lock_mutex_abstimed(*clone, thread, NULL)) < 0)
         goto out;
-
-    clone_is_locked = 1;
-
 #else
     if ((ret = wolfsentry_context_alloc_1(&wolfsentry->hpi, clone)) < 0)
         WOLFSENTRY_ERROR_RERETURN(ret);
@@ -3691,16 +3686,8 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_context_clone(
 
   out:
 
-    if ((ret < 0) && (*clone != NULL)) {
-#ifdef WOLFSENTRY_THREADSAFE
-        if (clone_is_locked) {
-            int ret2 = wolfsentry_context_unlock(*clone, thread);
-            if (ret2 < 0)
-                ret = ret2;
-        }
-#endif
+    if ((ret < 0) && (*clone != NULL))
         WOLFSENTRY_WARN_ON_FAILURE(wolfsentry_context_free(WOLFSENTRY_CONTEXT_ARGS_OUT_EX(clone)));
-    }
 
     WOLFSENTRY_ERROR_UNLOCK_AND_RERETURN(ret);
 }

--- a/tests/extra-test-config.json
+++ b/tests/extra-test-config.json
@@ -1,0 +1,28 @@
+{
+    "wolfsentry-config-version" : 1,
+    "static-routes-insert" : [
+    {
+        "parent-event" : "static-route-parent",
+        "direction-in" : true,
+        "direction-out" : true,
+        "penalty-boxed" : false,
+        "green-listed" : true,
+        "dont-count-hits" : false,
+        "dont-count-current-connections" : false,
+        "family" : "inet",
+        "protocol" : "tcp",
+        "remote" : {
+            "address" : "10.20.30.40",
+            "prefix-bits" : 32
+        },
+        "local" : {
+            "address" : "50.60.70.80",
+            "prefix-bits" : 32,
+            "port" : 13579
+        }
+    }
+    ],
+    "user-values" : {
+        "extra-user-string" : "extra hello"
+    }
+}


### PR DESCRIPTION
fixes for and related to `WOLFSENTRY_CONFIG_LOAD_FLAG_NO_FLUSH`:

properly free promotion reservation in `wolfsentry_config_json_init_ex()` if obtained;

just copy `fallthrough_route` pointer in `wolfsentry_route_table_clone_header()`;

add missing assignment of `new->prev` in `wolfsentry_table_clone()`;

remove obsolete unlock logic in `wolfsentry_context_clone()`;

add `WOLFSENTRY_CONFIG_LOAD_FLAG_NO_FLUSH` coverage to `test_json()` unit test.
