### PR TITLE
20230421-more-no-flush-fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,9 @@ AR_VERSION := $(shell $(AR) --version 2>&1 | sed "s/'/'\\\\''/g")
 AR_IS_GNU_AR := $(shell if [[ '$(AR_VERSION)' =~ 'GNU' ]]; then echo 1; else echo 0; fi)
 
 ifndef C_WARNFLAGS
-    C_WARNFLAGS := -Wall -Wextra -Werror -Wformat=2 -Winit-self -Wmissing-include-dirs -Wunknown-pragmas -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wconversion -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations -Wmissing-format-attribute -Wpointer-arith -Woverlength-strings -Wredundant-decls -Winline -Winvalid-pch -Wdouble-promotion -Wvla -Wno-type-limits
+    C_WARNFLAGS := -Wall -Wextra -Werror -Wformat=2 -Winit-self -Wmissing-include-dirs -Wunknown-pragmas -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Wconversion -Wstrict-prototypes -Wold-style-definition -Wmissing-prototypes -Wmissing-declarations -Wmissing-format-attribute -Wpointer-arith -Woverlength-strings -Wredundant-decls -Winline -Winvalid-pch -Wdouble-promotion -Wvla -Wno-type-limits -Wdeclaration-after-statement -Wnested-externs
     ifeq "$(CC_IS_GCC)" "1"
-        C_WARNFLAGS += -Wjump-misses-init -Wlogical-op
+        C_WARNFLAGS += -Wjump-misses-init -Wlogical-op -Wlogical-not-parentheses -Wpacked-not-aligned
     endif
 endif
 

--- a/src/wolfsentry_internal.h
+++ b/src/wolfsentry_internal.h
@@ -488,6 +488,11 @@ WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_route_table_clone_header(
 WOLFSENTRY_LOCAL void wolfsentry_route_table_free(
     WOLFSENTRY_CONTEXT_ARGS_IN,
     struct wolfsentry_route_table **route_table);
+WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_route_copy_metadata(
+    WOLFSENTRY_CONTEXT_ARGS_IN,
+    struct wolfsentry_route_table *from_table,
+    struct wolfsentry_context *dest_context,
+    struct wolfsentry_route_table *to_table);
 WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_kv_table_init(
     struct wolfsentry_kv_table *kv_table);
 WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_kv_table_clone_header(


### PR DESCRIPTION
`Makefile`: add `-Wmissing-prototypes` `-Wdeclaration-after-statement` `-Wnested-externs`, and for `gcc`, `-Wlogical-not-parentheses` `-Wpacked-not-aligned`;

fix several functionally inconsequential infractions exposed by new warnings;

fix `WOLFSENTRY_EXIT_ON_SUCCESS()` macro in `unittests.c` to properly test for `>= 0`, and fix 3 `WOLFSENTRY_EXIT_ON_SUCCESS()` tests that are now correctly succeeding;

add `wolfsentry_route_copy_metadata()` to `routes.c`, and call it from `wolfsentry_context_exchange()`;

in `wolfsentry_route_event_dispatch_1()`, when result falls back to default policy, return `USED_FALLBACK` success code;

fix accounting bugs re `read2write_waiter_read_count` in `wolfsentry_lock_{shared_abstimed,shared2mutex_reserve,shared2mutex_abandon,unlock}()`, and change `wolfsentry_lock_unlock()` semantics so that final unlock while holding reservation is not an error and implicitly drops the reservation;

in `src/json/load_config.c`, add `wolfsentry_json_process_state.got_reservation`, use the `LOCK_OK_AND_GOT_RESV` to set it in `wolfsentry_config_json_init_ex()`, and refactor unlock code in `wolfsentry_config_json_init_ex()` and `wolfsentry_config_json_fini()` to use it;

tweak order of events around `wolfsentry_context_exchange() `in `wolfsentry_config_json_fini()` to interact correctly with `wolfsentry_route_copy_metadata()`;

add an array of should-fail json packages to `unittests.c`:`test_json()`.
