### PR TITLE
20230707-fix-cmp_addrs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Fixed copying of route table header fields (table config) when cloning or rebuil
 
 Implemented proper locking in `wolfsentry_route_get_reference()`, and corresponding lock assertion in `wolfsentry_table_cursor_init()`.
 
+Fixed logic in address matching to properly match zero-length addresses when peforming subnet matching, even if the corresponding `_ADDR_WILDCARD` flag bit is clear.
+
 ## Self-Test Enhancements
 
 `Makefile.analyzers`: add `-fshort-enums` variants to `sanitize-all` and `sanitize-all-gcc` recipes, and add `short-enums-test` recipe.

--- a/src/routes.c
+++ b/src/routes.c
@@ -54,7 +54,7 @@ static inline int cmp_addrs(
     if (min_addr_len == 0) {
         if (left_addr_len == right_addr_len)
             return 0;
-        else if (wildcard_p) {
+        else if (wildcard_p || match_subnets_p) {
             *inexact_p = 1;
             return 0;
         } else if (left_addr_len != 0)

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -1061,6 +1061,19 @@ static int test_static_routes (void) {
     WOLFSENTRY_EXIT_ON_FALSE(n_deleted == 1);
 
 
+    /* retest with explicit wildcard bit cleared, but addr_len still 0. */
+    WOLFSENTRY_CLEAR_BITS(flags_wildcard, WOLFSENTRY_ROUTE_FLAG_SA_LOCAL_ADDR_WILDCARD);
+    WOLFSENTRY_EXIT_ON_FAILURE(wolfsentry_route_insert(WOLFSENTRY_CONTEXT_ARGS_OUT, NULL /* caller_arg */, &remote_wildcard.sa, &local_wildcard.sa, flags_wildcard, 0 /* event_label_len */, 0 /* event_label */, &id, &action_results));
+
+    WOLFSENTRY_EXIT_ON_FAILURE(wolfsentry_route_event_dispatch(WOLFSENTRY_CONTEXT_ARGS_OUT, &remote.sa, &local.sa, flags, NULL /* event_label */, 0 /* event_label_len */, NULL /* caller_arg */,
+                                                           &route_id, &inexact_matches, &action_results));
+    WOLFSENTRY_EXIT_ON_FALSE(route_id == id);
+    WOLFSENTRY_EXIT_ON_FALSE(WOLFSENTRY_CHECK_BITS(inexact_matches, WOLFSENTRY_ROUTE_FLAG_SA_LOCAL_ADDR_WILDCARD));
+
+    WOLFSENTRY_EXIT_ON_FAILURE(wolfsentry_route_delete(WOLFSENTRY_CONTEXT_ARGS_OUT, NULL /* caller_arg */, &remote_wildcard.sa, &local_wildcard.sa, flags_wildcard, 0 /* event_label_len */, 0 /* event_label */, &action_results, &n_deleted));
+    WOLFSENTRY_EXIT_ON_FALSE(n_deleted == 1);
+
+
     remote_wildcard = remote;
     local_wildcard = local;
     flags_wildcard = flags;


### PR DESCRIPTION
`src/routes.c`: in `cmp_addrs(),` in the `min_addr_len == 0` case, return match if `match_subnets_p`, not just if `wildcard_p`.
