### PR TITLE
Adjust toolpaths to use $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
-SHELL := /bin/bash
+SHELL := bash
 
 ifeq "$(V)" "1"
     override undefine VERY_QUIET

--- a/scripts/build_wolfsentry_options_h.awk
+++ b/scripts/build_wolfsentry_options_h.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 # build_wolfsentry_options_h.awk
 #


### PR DESCRIPTION
This change helps that wolfsentry could be built under NixOS where tools, e.g. bash are usually not under `/bin/bash` but covered by `$PATH`. By using `/usr/bin/env` in shebangs and otherwise relative paths the build works fine under NixOS.