### PR TITLE
20231207-replace_rule_transactionally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
 
-SHELL := /bin/bash
+SHELL := bash
 
 ifeq "$(V)" "1"
     override undefine VERY_QUIET

--- a/scripts/build_wolfsentry_options_h.awk
+++ b/scripts/build_wolfsentry_options_h.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 # build_wolfsentry_options_h.awk
 #

--- a/scripts/convert_copyright_boilerplate.awk
+++ b/scripts/convert_copyright_boilerplate.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/awk -f
+#!/usr/bin/env -S awk -f
 
 # update_copyright_boilerplate.awk
 #

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # wolfsentry/scripts/pre-push.sh
 #


### PR DESCRIPTION
`tests/unittests.c`: add `replace_rule_transactionally()`, and use it in `test_static_routes()` for a workout.

`Makefile`, `scripts/`: update shebang and `SHELL` paths to honor environment `PATH`.

Note, supersedes #60 
