### PR TITLE
20231208-Wconversion-gcc-7v5-workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@
 
 SHELL := bash
 
+AWK := awk
+
 ifeq "$(V)" "1"
     override undefine VERY_QUIET
 endif
@@ -257,7 +259,7 @@ endif
 ifndef USER_SETTINGS_FILE
 $(BUILD_TOP)/wolfsentry/wolfsentry_options.h: $(SRC_TOP)/scripts/build_wolfsentry_options_h.awk $(BUILD_TOP)/.build_params
 	@[ -d $(BUILD_TOP)/wolfsentry ] || mkdir -p $(BUILD_TOP)/wolfsentry
-	@echo '$(CFLAGS)' | $< > $@
+	@echo '$(CFLAGS)' | $(AWK) -f $< > $@
 endif
 
 $(addprefix $(BUILD_TOP)/src/,$(SRCS:.c=.o)) $(addprefix $(BUILD_TOP)/src/,$(SRCS:.c=.So)): $(BUILD_TOP)/.build_params $(OPTIONS_FILE) $(SRC_TOP)/Makefile

--- a/Makefile.maintenance
+++ b/Makefile.maintenance
@@ -21,7 +21,7 @@
 .PHONY: release
 release:
 	@if [[ -z "$(RELEASE)" ]]; then echo "Can't make release -- version isn't known."; exit 1; fi
-	@cd "$(SRC_TOP)" && git show "$(RELEASE):wolfsentry/wolfsentry.h" | awk '/^#define WOLFSENTRY_VERSION_MAJOR /{major=$$3; next;}/^#define WOLFSENTRY_VERSION_MINOR /{minor=$$3; next;}/^#define WOLFSENTRY_VERSION_TINY /{tiny=$$3; next;} {if ((major != "") && (minor != "") && (tiny != "")) {exit(0);}} END { if ("v" major "." minor "." tiny == "$(RELEASE)") {exit(0);} else {printf("make release: tagged version \"%s\" doesn'\''t match version in header \"v%s.%s.%s\".\n", "$(RELEASE)", major, minor, tiny) > "/dev/stderr"; exit(1);}; }'
+	@cd "$(SRC_TOP)" && git show "$(RELEASE):wolfsentry/wolfsentry.h" | $(AWK) '/^#define WOLFSENTRY_VERSION_MAJOR /{major=$$3; next;}/^#define WOLFSENTRY_VERSION_MINOR /{minor=$$3; next;}/^#define WOLFSENTRY_VERSION_TINY /{tiny=$$3; next;} {if ((major != "") && (minor != "") && (tiny != "")) {exit(0);}} END { if ("v" major "." minor "." tiny == "$(RELEASE)") {exit(0);} else {printf("make release: tagged version \"%s\" doesn'\''t match version in header \"v%s.%s.%s\".\n", "$(RELEASE)", major, minor, tiny) > "/dev/stderr"; exit(1);}; }'
 	@REFMAN_UPDATED_AT=$$(git --no-pager log -n 1 --pretty=format:%at '$(RELEASE)' doc/wolfSentry_refman.pdf 2>/dev/null); if [[ -n "$$REFMAN_UPDATED_AT" && ($$(git --no-pager log -n 1 --pretty=format:%at '$(RELEASE)' wolfsentry/ doc/ ChangeLog.md README.md) -gt "$$REFMAN_UPDATED_AT") ]]; then echo -e 'error: tag "$(RELEASE)" has doc/wolfSentry_refman.pdf older than header(s) and/or documentation.\nfix with: make doc/wolfSentry_refman.pdf && git commit -n doc/wolfSentry_refman.pdf && git tag -f "$(RELEASE)"' 1>&2; false; fi
 ifndef VERY_QUIET
 	@echo "generating release archive $${PWD}/wolfsentry-$(RELEASE).zip"
@@ -44,7 +44,7 @@ endif
 	trap "rm -rf \"$$workdir\"" EXIT; \
 	git archive --format=tar --prefix="wolfsentry-$(RELEASE)-commercial/" --worktree-attributes "$(RELEASE)" | (cd "$$workdir" && tar -xf -) || exit $$?; \
 	pushd "$$workdir" >/dev/null || exit $$?; \
-	$(SRC_TOP)/scripts/convert_copyright_boilerplate.awk $$(find . -name Makefile\* -o -name '*.[ch]' -o -name '*.sh' -o -name '*.awk') || exit $$?; \
+	$(AWK) -f $(SRC_TOP)/scripts/convert_copyright_boilerplate.awk $$(find . -name Makefile\* -o -name '*.[ch]' -o -name '*.sh' -o -name '*.awk') || exit $$?; \
 	if [[ -e "$${DEST_DIR}/wolfsentry-$(RELEASE)-commercial.7z" ]]; then rm "$${DEST_DIR}/wolfsentry-$(RELEASE)-commercial.7z" || exit $$?; fi; \
 	7za a -r -mmt -mhe=on -mx=9 -ms=on -p"$$the_password" "$${DEST_DIR}/wolfsentry-$(RELEASE)-commercial.7z" "wolfsentry-$(RELEASE)-commercial" 1>/dev/null || exit $$?; \
 	echo -n "com-bundle SHA256: " && sha256sum "$${DEST_DIR}/wolfsentry-$(RELEASE)-commercial.7z"

--- a/scripts/build_wolfsentry_options_h.awk
+++ b/scripts/build_wolfsentry_options_h.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S awk -f
+#!/usr/bin/awk -f
 
 # build_wolfsentry_options_h.awk
 #

--- a/scripts/convert_copyright_boilerplate.awk
+++ b/scripts/convert_copyright_boilerplate.awk
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S awk -f
+#!/usr/bin/awk -f
 
 # update_copyright_boilerplate.awk
 #

--- a/src/json/load_config.c
+++ b/src/json/load_config.c
@@ -848,7 +848,7 @@ static wolfsentry_errcode_t handle_route_endpoint_clause(struct wolfsentry_json_
          * move it to right-justified position.
          */
         if ((sa->addr_len != 0) && (sa->addr_len != addr_size)) {
-            size_t pad_bytes = WOLFSENTRY_BITS_TO_BYTES(addr_size - sa->addr_len);
+            size_t pad_bytes = WOLFSENTRY_BITS_TO_BYTES((size_t)addr_size - (size_t)sa->addr_len);
             memmove(sa->addr + pad_bytes, sa->addr, sa->addr_len);
             memset(sa->addr, 0, pad_bytes);
         }


### PR DESCRIPTION
`src/json/load_config.c`: in `handle_route_endpoint_clause()`, add a couple casts to work around an implicit-promotion bug in gcc-7.5.
