### PR TITLE
20240201-LLVM-19-cleanups

### DIFF
--- a/Makefile.analyzers
+++ b/Makefile.analyzers
@@ -33,7 +33,7 @@ endif
 # lock in the expected major versions of LLVM/clang/compiler-rt-sanitizers, in
 # order of preference:
 ifndef CLANG_PATH
-	CLANG_PATH:=/usr/lib/llvm/18/bin:/usr/lib/llvm-18:/usr/lib/llvm/17/bin:/usr/lib/llvm-17:/usr/lib/llvm/16/bin:/usr/lib/llvm-16:/usr/lib/llvm/15/bin:/usr/lib/llvm-15:/usr/lib/llvm/14/bin:/usr/lib/llvm-14:/opt/homebrew/opt/llvm/bin
+	CLANG_PATH:=/usr/lib/llvm/19/bin:/usr/lib/llvm/18/bin:/usr/lib/llvm-18:/usr/lib/llvm/17/bin:/usr/lib/llvm-17:/usr/lib/llvm/16/bin:/usr/lib/llvm-16:/usr/lib/llvm/15/bin:/usr/lib/llvm-15:/usr/lib/llvm/14/bin:/usr/lib/llvm-14:/opt/homebrew/opt/llvm/bin
 endif
 
 valgrind-all-clang: PATH:=$(CLANG_PATH):$(PATH)
@@ -227,7 +227,7 @@ clang-tidy-build-test:
 	 command -v clang-tidy 1>/dev/null || { echo 'clang-tidy not found -- skipping $@.'; exit 0; }; \
 	 CLANG=clang CLANG_TIDY=clang-tidy CLANG_TIDY_EXTRA_ARGS='--use-color=1' $(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-clang-tidy-builds" CC="$(REPO_ROOT)/../testing/git-hooks/clang-tidy-builder.sh" clean; \
 	 . $(REPO_ROOT)/scripts/analyzer-config.sh && \
-	 CLANG=clang CLANG_TIDY=clang-tidy CLANG_TIDY_EXTRA_ARGS='--use-color=1' $(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-clang-tidy-builds" CC="$(REPO_ROOT)/../testing/git-hooks/clang-tidy-builder.sh" test && \
+	 CLANG=clang CLANG_TIDY=clang-tidy CLANG_TIDY_EXTRA_ARGS='--use-color=1' $(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-clang-tidy-builds" CC="$(REPO_ROOT)/../testing/git-hooks/clang-tidy-builder.sh" EXTRA_CFLAGS='-Wunreachable-code-aggressive -Wthread-safety -Wloop-analysis -Wenum-compare-conditional -fcolor-diagnostics -fcomplete-member-pointers -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare' test && \
 	 CLANG=clang CLANG_TIDY=clang-tidy CLANG_TIDY_EXTRA_ARGS='--use-color=1' $(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-clang-tidy-builds" CC="$(REPO_ROOT)/../testing/git-hooks/clang-tidy-builder.sh" clean && \
 	 echo 'passed: $@.'
 

--- a/src/addr_families.c
+++ b/src/addr_families.c
@@ -323,7 +323,7 @@ WOLFSENTRY_LOCAL wolfsentry_errcode_t wolfsentry_addr_family_clone(
     if ((*new_bynumber = (struct wolfsentry_addr_family_bynumber *)WOLFSENTRY_MALLOC_1(dest_context->hpi.allocator, sizeof **new_bynumber)) == NULL)
         WOLFSENTRY_ERROR_RETURN(SYS_RESOURCE_FAILED);
     if ((*new_byname = (struct wolfsentry_addr_family_byname *)WOLFSENTRY_MALLOC_1(dest_context->hpi.allocator, byname_size)) == NULL) {
-        (void)WOLFSENTRY_FREE_1(dest_context->hpi.allocator, new_byname);
+        (void)WOLFSENTRY_FREE_1(dest_context->hpi.allocator, (void *)new_byname);
         WOLFSENTRY_ERROR_RETURN(SYS_RESOURCE_FAILED);
     }
     memcpy(*new_bynumber, src_bynumber, sizeof **new_bynumber);
@@ -501,7 +501,7 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_addr_family_pton(
             WOLFSENTRY_CONTEXT_ARGS_OUT,
             wolfsentry->addr_families_byname,
             family_name,
-            (int)family_name_len,
+            family_name_len,
             &addr_family);
         WOLFSENTRY_UNLOCK_FOR_RETURN();
         if (ret >= 0) {

--- a/src/json/centijson_dom.c
+++ b/src/json/centijson_dom.c
@@ -270,7 +270,7 @@ json_dom_process(JSON_TYPE type, const unsigned char* data, size_t data_size, vo
 
             if(new_path_alloc == 0)
                 new_path_alloc = 32;
-            new_path = (JSON_VALUE**) realloc(dom_parser->path, new_path_alloc * sizeof(JSON_VALUE*));
+            new_path = (JSON_VALUE**) realloc((void *)dom_parser->path, new_path_alloc * sizeof(JSON_VALUE*));
             if(new_path == NULL)
                 return JSON_ERR_OUTOFMEMORY;
 
@@ -360,7 +360,7 @@ int json_dom_clean(JSON_DOM_PARSER* dom_parser) {
     if (ret < 0)
         return ret;
 
-    free(dom_parser->path);
+    free((void *)dom_parser->path);
     dom_parser->path = NULL;
 
     dom_parser->flags &= ~JSON_DOM_FLAG_INITED;
@@ -605,9 +605,9 @@ json_dom_dump_helper(
             if(n > 0) {
                 size_t keys_size;
 #ifdef WOLFSENTRY
-                keys = json_malloc(WOLFSENTRY_CONTEXT_ARGS_OUT_EX(allocator), sizeof(JSON_VALUE*) * n);
+                keys = (const JSON_VALUE**)json_malloc(WOLFSENTRY_CONTEXT_ARGS_OUT_EX(allocator), sizeof(JSON_VALUE*) * n);
 #else
-                keys = malloc(sizeof(JSON_VALUE*) * n);
+                keys = (const JSON_VALUE**)malloc(sizeof(JSON_VALUE*) * n);
 #endif
                 if(keys == NULL)
                     return JSON_ERR_OUTOFMEMORY;
@@ -658,9 +658,9 @@ json_dom_dump_helper(
                 }
 
 #ifdef WOLFSENTRY
-                json_free(WOLFSENTRY_CONTEXT_ARGS_OUT_EX(allocator), keys);
+                json_free(WOLFSENTRY_CONTEXT_ARGS_OUT_EX(allocator), (void *)keys);
 #else
-                free(keys);
+                free((void *)keys);
 #endif
                 if(ret < 0)
                     return ret;

--- a/src/json/centijson_sax.c
+++ b/src/json/centijson_sax.c
@@ -536,12 +536,12 @@ json_string_automaton(JSON_PARSER* parser, const unsigned char* input, size_t si
     size_t off = 0;
 
     if(type == JSON_KEY) {
-        ignore_ill_utf8 = (parser->config.flags & JSON_IGNOREILLUTF8KEY);
-        fix_ill_utf8 = (parser->config.flags & JSON_FIXILLUTF8KEY);
+        ignore_ill_utf8 = ((parser->config.flags & JSON_IGNOREILLUTF8KEY) != 0);
+        fix_ill_utf8 = ((parser->config.flags & JSON_FIXILLUTF8KEY) != 0);
         max_len = parser->config.max_key_len;
     } else {
-        ignore_ill_utf8 = (parser->config.flags & JSON_IGNOREILLUTF8VALUE);
-        fix_ill_utf8 = (parser->config.flags & JSON_FIXILLUTF8VALUE);
+        ignore_ill_utf8 = ((parser->config.flags & JSON_IGNOREILLUTF8VALUE) != 0);
+        fix_ill_utf8 = ((parser->config.flags & JSON_FIXILLUTF8VALUE) != 0);
         max_len = parser->config.max_string_len;
     }
 
@@ -622,19 +622,19 @@ json_string_automaton(JSON_PARSER* parser, const unsigned char* input, size_t si
                  */
                 if(IS_IN(ch, 0xc2, 0xdf)) {
                     parser->substate = 1;
-                } else if((unsigned char) ch == 0xe0) {
+                } else if(ch == 0xe0) {
                     parser->substate = 4;
                 } else if(IS_IN(ch, 0xe1, 0xec)) {
                     parser->substate = 2;
-                } else if((unsigned char) ch == 0xed) {
+                } else if(ch == 0xed) {
                     parser->substate = 5;
                 } else if(IS_IN(ch, 0xee, 0xef)) {
                     parser->substate = 2;
-                } else if((unsigned char) ch == 0xf0) {
+                } else if(ch == 0xf0) {
                     parser->substate = 6;
                 } else if(IS_IN(ch, 0xf1, 0xf3)) {
                     parser->substate = 3;
-                } else if((unsigned char) ch == 0xf4) {
+                } else if(ch == 0xf4) {
                     parser->substate = 7;
                 } else if(fix_ill_utf8) {
                     if(json_buf_append(parser, fffd, fffd_size) < 0)
@@ -651,7 +651,7 @@ json_string_automaton(JSON_PARSER* parser, const unsigned char* input, size_t si
             }
         } else if(parser->substate <= 7) {
             /* Should be trailing UTF-8 byte. */
-            if(parser->substate <= 3  &&  ((unsigned char)(ch) & 0xc0) == 0x80) {
+            if(parser->substate <= 3  &&  (ch & 0xc0) == 0x80) {
                 parser->substate--;
             } else if(parser->substate == 4  &&  IS_IN(ch, 0xa0, 0xbf)) {
                 parser->substate = 1;
@@ -679,7 +679,7 @@ json_string_automaton(JSON_PARSER* parser, const unsigned char* input, size_t si
                  * I.e. we have to go back to the previous leading byte
                  * (including it).
                  */
-                while(((unsigned char)(parser->buf[parser->buf_used-1]) & 0xc0) == 0x80)
+                while((parser->buf[parser->buf_used-1] & 0xc0) == 0x80)
                     parser->buf_used--; /* Cancel all the trailing bytes. */
                 parser->buf_used--;     /* Cancel the leading byte. */
                 if(json_buf_append(parser, fffd, fffd_size) < 0)

--- a/src/json/centijson_value.c
+++ b/src/json/centijson_value.c
@@ -268,26 +268,22 @@ json_value_is_compatible(const JSON_VALUE* v, JSON_VALUE_TYPE type)
             return (type == JSON_VALUE_INT64 || type == JSON_VALUE_FLOAT || type == JSON_VALUE_DOUBLE)  ||
                    (type == JSON_VALUE_UINT32 && json_value_int32(v) >= 0)  ||
                    (type == JSON_VALUE_UINT64 && json_value_int32(v) >= 0);
-            break;
 
         case JSON_VALUE_UINT32:
             return (type == JSON_VALUE_INT64 || type == JSON_VALUE_UINT64 || type == JSON_VALUE_FLOAT || type == JSON_VALUE_DOUBLE)  ||
                    (type == JSON_VALUE_INT32 && json_value_uint32(v) <= INT32_MAX);
-            break;
 
         case JSON_VALUE_INT64:
             return (type == JSON_VALUE_FLOAT || type == JSON_VALUE_DOUBLE)  ||
                    (type == JSON_VALUE_INT32 && json_value_int64(v) >= INT32_MIN && json_value_int64(v) <= INT32_MAX)  ||
                    (type == JSON_VALUE_UINT32 && json_value_int64(v) >= 0 && json_value_int64(v) <= UINT32_MAX)  ||
                    (type == JSON_VALUE_UINT64 && json_value_int64(v) >= 0);
-            break;
 
         case JSON_VALUE_UINT64:
             return (type == JSON_VALUE_FLOAT || type == JSON_VALUE_DOUBLE)  ||
                    (type == JSON_VALUE_INT32 && json_value_uint64(v) <= INT32_MAX)  ||
                    (type == JSON_VALUE_UINT32 && json_value_uint64(v) <= UINT32_MAX)  ||
                    (type == JSON_VALUE_INT64 && json_value_uint64(v) <= INT64_MAX);
-            break;
 
         case JSON_VALUE_FLOAT:
             return (type == JSON_VALUE_DOUBLE)  ||
@@ -295,7 +291,6 @@ json_value_is_compatible(const JSON_VALUE* v, JSON_VALUE_TYPE type)
                    (type == JSON_VALUE_UINT32 && json_value_float(v) == (float)json_value_uint32(v))  ||
                    (type == JSON_VALUE_INT64 && json_value_float(v) == (float)json_value_int64(v))  ||
                    (type == JSON_VALUE_UINT64 && json_value_float(v) == (float)json_value_uint64(v));
-            break;
 
         case JSON_VALUE_DOUBLE:
             return (type == JSON_VALUE_FLOAT)  ||
@@ -303,7 +298,6 @@ json_value_is_compatible(const JSON_VALUE* v, JSON_VALUE_TYPE type)
                    (type == JSON_VALUE_UINT32 && json_value_double(v) == (double)json_value_uint32(v))  ||
                    (type == JSON_VALUE_INT64 && json_value_double(v) == (double)json_value_int64(v))  ||
                    (type == JSON_VALUE_UINT64 && json_value_double(v) == (double)json_value_uint64(v));
-            break;
 
         default:
             break;
@@ -695,7 +689,7 @@ json_value_int32(const JSON_VALUE* v)
     } ret;
 
     switch(json_value_type(v)) {
-        case JSON_VALUE_INT32:     memcpy(&ret.i32, payload, sizeof(int32_t)); return (int32_t) ret.i32;
+        case JSON_VALUE_INT32:     memcpy(&ret.i32, payload, sizeof(int32_t)); return ret.i32;
         case JSON_VALUE_UINT32:    memcpy(&ret.u32, payload, sizeof(uint32_t)); return (int32_t) ret.u32;
         case JSON_VALUE_INT64:     memcpy(&ret.i64, payload, sizeof(int64_t)); return (int32_t) ret.i64;
         case JSON_VALUE_UINT64:    memcpy(&ret.u64, payload, sizeof(uint64_t)); return (int32_t) ret.u64;
@@ -720,7 +714,7 @@ json_value_uint32(const JSON_VALUE* v)
 
     switch(json_value_type(v)) {
         case JSON_VALUE_INT32:     memcpy(&ret.i32, payload, sizeof(int32_t)); return (uint32_t) ret.i32;
-        case JSON_VALUE_UINT32:    memcpy(&ret.u32, payload, sizeof(uint32_t)); return (uint32_t) ret.u32;
+        case JSON_VALUE_UINT32:    memcpy(&ret.u32, payload, sizeof(uint32_t)); return ret.u32;
         case JSON_VALUE_INT64:     memcpy(&ret.i64, payload, sizeof(int64_t)); return (uint32_t) ret.i64;
         case JSON_VALUE_UINT64:    memcpy(&ret.u64, payload, sizeof(uint64_t)); return (uint32_t) ret.u64;
         case JSON_VALUE_FLOAT:     memcpy(&ret.f, payload, sizeof(float)); return ROUNDF(uint32_t, ret.f);
@@ -745,7 +739,7 @@ json_value_int64(const JSON_VALUE* v)
     switch(json_value_type(v)) {
         case JSON_VALUE_INT32:     memcpy(&ret.i32, payload, sizeof(int32_t)); return (int64_t) ret.i32;
         case JSON_VALUE_UINT32:    memcpy(&ret.u32, payload, sizeof(uint32_t)); return (int64_t) ret.u32;
-        case JSON_VALUE_INT64:     memcpy(&ret.i64, payload, sizeof(int64_t)); return (int64_t) ret.i64;
+        case JSON_VALUE_INT64:     memcpy(&ret.i64, payload, sizeof(int64_t)); return ret.i64;
         case JSON_VALUE_UINT64:    memcpy(&ret.u64, payload, sizeof(uint64_t)); return (int64_t) ret.u64;
         case JSON_VALUE_FLOAT:     memcpy(&ret.f, payload, sizeof(float)); return ROUNDF(int64_t, ret.f);
         case JSON_VALUE_DOUBLE:    memcpy(&ret.d, payload, sizeof(double)); return ROUNDD(int64_t, ret.d);
@@ -770,7 +764,7 @@ json_value_uint64(const JSON_VALUE* v)
         case JSON_VALUE_INT32:     memcpy(&ret.i32, payload, sizeof(int32_t)); return (uint64_t) ret.i32;
         case JSON_VALUE_UINT32:    memcpy(&ret.u32, payload, sizeof(uint32_t)); return (uint64_t) ret.u32;
         case JSON_VALUE_INT64:     memcpy(&ret.i64, payload, sizeof(int64_t)); return (uint64_t) ret.i64;
-        case JSON_VALUE_UINT64:    memcpy(&ret.u64, payload, sizeof(uint64_t)); return (uint64_t) ret.u64;
+        case JSON_VALUE_UINT64:    memcpy(&ret.u64, payload, sizeof(uint64_t)); return ret.u64;
         case JSON_VALUE_FLOAT:     memcpy(&ret.f, payload, sizeof(float)); return ROUNDF(uint64_t, ret.f);
         case JSON_VALUE_DOUBLE:    memcpy(&ret.d, payload, sizeof(double)); return ROUNDD(uint64_t, ret.d);
         default:            return UINT64_MAX;
@@ -1367,7 +1361,7 @@ json_value_dict_get_or_add_(
 #endif
     JSON_VALUE* v, const unsigned char* key, size_t key_len)
 {
-    DICT* d = json_value_dict_payload((JSON_VALUE*) v);
+    DICT* d = json_value_dict_payload(v);
     RBTREE* node = (d != NULL) ? d->root : NULL;
 #ifdef WOLFSENTRY_NO_ALLOCA
     RBTREE *path[RBTREE_MAX_HEIGHT];
@@ -1551,7 +1545,7 @@ json_value_dict_remove_(
 #endif
     JSON_VALUE* v, const unsigned char* key, size_t key_len)
 {
-    DICT* d = json_value_dict_payload((JSON_VALUE*) v);
+    DICT* d = json_value_dict_payload(v);
     RBTREE* node = (d != NULL) ? d->root : NULL;
     RBTREE* single_child;
 #ifdef WOLFSENTRY_NO_ALLOCA
@@ -1775,7 +1769,7 @@ json_value_dict_clean(
 #endif
     JSON_VALUE* v)
 {
-    DICT* d = json_value_dict_payload((JSON_VALUE*) v);
+    DICT* d = json_value_dict_payload(v);
     RBTREE **stack;
     int stack_size;
     RBTREE* node;
@@ -1819,7 +1813,7 @@ json_value_dict_clean(
     else
         memset(d, 0, OFFSETOF(DICT, order_head));
 
-    free(stack);
+    free((void *)stack);
 
     return 0;
 }
@@ -1959,7 +1953,7 @@ json_value_clone(WOLFSENTRY_CONTEXT_ARGS_IN_EX(struct wolfsentry_allocator *allo
                     stack_size += json_value_dict_leftmost_path(stack + stack_size, src_dict_node->right);
                 }
 
-                free(stack);
+                free((void *)stack);
 
                 break;
             }

--- a/src/kv.c
+++ b/src/kv.c
@@ -211,7 +211,6 @@ static inline int wolfsentry_kv_value_eq_1(struct wolfsentry_kv_pair *a, struct 
     default:
         return 0;
     }
-    return 0;
 }
 
 /* same as wolfsentry_kv_insert unless key already exists.  if it does and

--- a/src/routes.c
+++ b/src/routes.c
@@ -795,7 +795,7 @@ static wolfsentry_errcode_t wolfsentry_route_init_by_exports(
         WOLFSENTRY_ERROR_RETURN(INVALID_ARG);
     if ((unsigned)data_addr_offset > MAX_UINT_OF(uint16_t))
         WOLFSENTRY_ERROR_RETURN(NUMERIC_ARG_TOO_BIG);
-    if (new_size < offsetof(struct wolfsentry_route, data) + (size_t)data_addr_offset + WOLFSENTRY_BITS_TO_BYTES(route_exports->remote.addr_len) + WOLFSENTRY_BITS_TO_BYTES(route_exports->local.addr_len))
+    if (new_size < offsetof(struct wolfsentry_route, data) + data_addr_offset + WOLFSENTRY_BITS_TO_BYTES(route_exports->remote.addr_len) + WOLFSENTRY_BITS_TO_BYTES(route_exports->local.addr_len))
         WOLFSENTRY_ERROR_RETURN(BUFFER_TOO_SMALL);
     if (! (route_exports->flags & (WOLFSENTRY_ROUTE_FLAG_DIRECTION_IN | WOLFSENTRY_ROUTE_FLAG_DIRECTION_OUT)))
         WOLFSENTRY_ERROR_RETURN(INVALID_ARG);
@@ -863,10 +863,10 @@ static wolfsentry_errcode_t wolfsentry_route_init_by_exports(
     if (data_addr_offset > 0) {
         if (route_exports->private_data != NULL) {
             memcpy(new->data, route_exports->private_data, route_exports->private_data_size); /* copy private data. */
-            if ((size_t)data_addr_offset > route_exports->private_data_size)
+            if (data_addr_offset > route_exports->private_data_size)
                 memset((byte *)new->data + route_exports->private_data_size, 0, data_addr_offset - route_exports->private_data_size); /* zero the leftovers. */
         } else
-            memset(new->data, 0, (size_t)data_addr_offset); /* zero private data. */
+            memset(new->data, 0, data_addr_offset); /* zero private data. */
     }
 
     new->meta.purge_after = route_exports->meta.purge_after;
@@ -2108,7 +2108,7 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_route_get_reference(
         if ((ret = wolfsentry_event_get_reference(WOLFSENTRY_CONTEXT_ARGS_OUT, event_label, event_label_len, &event)) < 0)
             WOLFSENTRY_ERROR_UNLOCK_AND_RERETURN(ret);
     }
-    ret = wolfsentry_route_lookup_1(WOLFSENTRY_CONTEXT_ARGS_OUT, table, remote, local, flags, event, exact_p, inexact_matches, (struct wolfsentry_route **)route, NULL /* action_results */);
+    ret = wolfsentry_route_lookup_1(WOLFSENTRY_CONTEXT_ARGS_OUT, table, remote, local, flags, event, exact_p, inexact_matches, route, NULL /* action_results */);
     if (event != NULL)
         WOLFSENTRY_WARN_ON_FAILURE(wolfsentry_event_drop_reference(WOLFSENTRY_CONTEXT_ARGS_OUT, event, NULL /* action_results */));
     WOLFSENTRY_UNLOCK_AND_RERETURN_IF_ERROR(ret);
@@ -3921,7 +3921,7 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_route_format_json(
             ret = wolfsentry_addr_family_ntop(WOLFSENTRY_CONTEXT_ARGS_OUT, r->sa_family, &addr_family, &family_name);
             if (WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
                 size_t family_name_len = strlen(family_name);
-                if (family_name_len + 2 > (size_t)*json_out_len)
+                if (family_name_len + 2 > *json_out_len)
                     ret = WOLFSENTRY_ERROR_ENCODE(BUFFER_TOO_SMALL);
                 else {
                     write_byte('"');

--- a/src/wolfsentry_util.c
+++ b/src/wolfsentry_util.c
@@ -1497,19 +1497,19 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_lock_init(struct wolfsentry_host_
     lock->read2write_reservation_holder = WOLFSENTRY_THREAD_NO_ID;
     lock->hpi = hpi;
 
-    if (sem_init(&lock->sem, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 0 /* value */) < 0)
+    if (sem_init(&lock->sem, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 0 /* value */) < 0)
         WOLFSENTRY_ERROR_RETURN(SYS_RESOURCE_FAILED);
     if (sem_post(&lock->sem) < 0)
         WOLFSENTRY_ERROR_RETURN(SYS_OP_FATAL);
-    if (sem_init(&lock->sem_read_waiters, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 0 /* value */) < 0) {
+    if (sem_init(&lock->sem_read_waiters, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 0 /* value */) < 0) {
         ret = WOLFSENTRY_ERROR_ENCODE(SYS_RESOURCE_FAILED);
         goto free_sem;
     }
-    if (sem_init(&lock->sem_write_waiters, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 0 /* value */) < 0) {
+    if (sem_init(&lock->sem_write_waiters, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 0 /* value */) < 0) {
         ret = WOLFSENTRY_ERROR_ENCODE(SYS_RESOURCE_FAILED);
         goto free_read_waiters;
     }
-    if (sem_init(&lock->sem_read2write_waiters, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 0 /* value */) < 0) {
+    if (sem_init(&lock->sem_read2write_waiters, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 0 /* value */) < 0) {
         ret = WOLFSENTRY_ERROR_ENCODE(SYS_RESOURCE_FAILED);
         goto free_write_waiters;
     }
@@ -1519,13 +1519,13 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_lock_init(struct wolfsentry_host_
     goto out;
 
   free_write_waiters:
-    if (sem_init(&lock->sem_write_waiters, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 0 /* value */) < 0)
+    if (sem_init(&lock->sem_write_waiters, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 0 /* value */) < 0)
         WOLFSENTRY_ERROR_RETURN(SYS_RESOURCE_FAILED);
   free_read_waiters:
-    if (sem_init(&lock->sem_read_waiters, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 0 /* value */) < 0)
+    if (sem_init(&lock->sem_read_waiters, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 0 /* value */) < 0)
         WOLFSENTRY_ERROR_RETURN(SYS_RESOURCE_FAILED);
   free_sem:
-    if (sem_init(&lock->sem, flags & WOLFSENTRY_LOCK_FLAG_PSHARED, 1 /* value */) < 0)
+    if (sem_init(&lock->sem, (flags & WOLFSENTRY_LOCK_FLAG_PSHARED) != 0, 1 /* value */) < 0)
         WOLFSENTRY_ERROR_RETURN(SYS_RESOURCE_FAILED);
 
   out:

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -4459,7 +4459,7 @@ static int test_json(const char *fname, const char *extra_fname) {
                                   0 /* dom_flags */, &p_root, &json_pos)) < 0) {
             void *p = memchr((const char *)(test_json_document + json_pos.offset), '\n', (size_t)st.st_size - json_pos.offset);
             int linelen = p ? ((int)((unsigned char *)p - (test_json_document + json_pos.offset)) + (int)json_pos.column_number - 1) :
-                ((int)((int)st.st_size - (int)json_pos.offset) + (int)json_pos.column_number - 1);
+                (((int)st.st_size - (int)json_pos.offset) + (int)json_pos.column_number - 1);
             if (WOLFSENTRY_ERROR_DECODE_SOURCE_ID(ret) == WOLFSENTRY_SOURCE_ID_UNSET)
                 fprintf(stderr, "json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with centijson code %d: %s\n", json_pos.offset,json_pos.line_number, json_pos.column_number, ret, json_dom_error_str(ret));
             else
@@ -5034,7 +5034,7 @@ static int test_json_corpus(void) {
                                       dom_flags, &p_root, &json_pos)) < 0) {
                 void *p = memchr((const char *)(scenario + json_pos.offset), '\n', (size_t)st.st_size - json_pos.offset);
                 int linelen = p ? ((int)((unsigned char *)p - (scenario + json_pos.offset)) + (int)json_pos.column_number - 1) :
-                    ((int)((int)st.st_size - (int)json_pos.offset) + (int)json_pos.column_number - 1);
+                    (((int)st.st_size - (int)json_pos.offset) + (int)json_pos.column_number - 1);
                 if (WOLFSENTRY_ERROR_DECODE_SOURCE_ID(ret) == WOLFSENTRY_SOURCE_ID_UNSET)
                     fprintf(stderr, "%s/%s: json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with centijson code %d: %s\n", corpus_path, scenario_ent->d_name, json_pos.offset,json_pos.line_number, json_pos.column_number, ret, json_dom_error_str(ret));
                 else

--- a/wolfsentry/wolfsentry_util.h
+++ b/wolfsentry/wolfsentry_util.h
@@ -43,7 +43,7 @@
     /*!< \brief Evaluates to a dummy instance of `element` in `structure`, e.g. to be passed to MAX_UINT_OF().  @hideinitializer */
 #endif
 #ifndef container_of
-#define container_of(ptr, container_type, member_name) ((container_type *)(void *)(((byte *)(ptr)) - offsetof(container_type, member_name)))
+#define container_of(ptr, container_type, member_name) ((container_type *)(void *)(((byte *)(ptr)) - offsetof(container_type, member_name))) /* NOLINT(bugprone-casting-through-void) */
     /*!< \brief Evaluates to a pointer to the struct of type `container_type` within which `ptr` points to the member named `member_name`.  @hideinitializer */
 #endif
 #ifndef length_of_array


### PR DESCRIPTION
cleanups for new benign warnings from LLVM 19 `clang`/`clang-tidy` with expanded warning scope:

* `readability-redundant-casting` (all fixed)
* `clang-diagnostic-unreachable-code-break` (all fixed)
* `bugprone-narrowing-conversions` (all fixed)
* `bugprone-multi-level-implicit-pointer-conversion` (all fixed)
* `bugprone-casting-through-void` (point suppression for container_of())
* `clang-analyzer-optin.core.EnumCastOutOfRange` (globally disabled)


no functional changes.  tested with `make check-all` and `make check-all GCC=gcc-14`.
