### PR TITLE
20241007-C23-fortify-source-llvm-20-etc

### DIFF
--- a/Makefile.analyzers
+++ b/Makefile.analyzers
@@ -33,7 +33,7 @@ endif
 # lock in the expected major versions of LLVM/clang/compiler-rt-sanitizers, in
 # order of preference:
 ifndef CLANG_PATH
-	CLANG_PATH:=/usr/lib/llvm/19/bin:/usr/lib/llvm/18/bin:/usr/lib/llvm-18:/usr/lib/llvm/17/bin:/usr/lib/llvm-17:/usr/lib/llvm/16/bin:/usr/lib/llvm-16:/usr/lib/llvm/15/bin:/usr/lib/llvm-15:/usr/lib/llvm/14/bin:/usr/lib/llvm-14:/opt/homebrew/opt/llvm/bin
+	CLANG_PATH:=/usr/lib/llvm/20/bin:/usr/lib/llvm/19/bin:/usr/lib/llvm/18/bin:/usr/lib/llvm-18:/usr/lib/llvm/17/bin:/usr/lib/llvm-17:/usr/lib/llvm/16/bin:/usr/lib/llvm-16:/usr/lib/llvm/15/bin:/usr/lib/llvm-15:/usr/lib/llvm/14/bin:/usr/lib/llvm-14:/opt/homebrew/opt/llvm/bin
 endif
 
 valgrind-all-clang: PATH:=$(CLANG_PATH):$(PATH)
@@ -233,7 +233,7 @@ clang-tidy-build-test:
 
 CPPCHECK := cppcheck
 
-CPPCHECK_COMMON_ARGS = --error-exitcode=2 --inline-suppr -j $$(($$(nproc) / 2)) $(QUIET_FLAG) --std=c99 -D__STDC__ -D__STDC_VERSION__=199901L -U__STRICT_ANSI__ -UFP_NAN -UFP_INFINITE -UFP_ZERO -UFP_SUBNORMAL -UFP_NORMAL -USIZE_T_32 -DWOLFSENTRY_CPPCHECK --suppress=legacyUninitvar --suppress=constParameterPointer  --suppress=constParameterCallback --suppress=unusedStructMember --suppress=variableScope --suppress=knownConditionTrueFalse --suppress=knownArgument --suppress=syntaxError:/usr/\* --suppress=unknownMacro:/usr/\* -I. -I/usr/include -I"$(shell $(CC) -print-file-name=include)" -I"$(LWIP_TOP_FOR_TEST)/src/include" -I"$(SRC_TOP)/ports/Linux-lwIP/include" -UWOLFSENTRY_SEMAPHORE_INCLUDE -UWOLFSENTRY_THREAD_INCLUDE
+CPPCHECK_COMMON_ARGS = --error-exitcode=2 --check-level=exhaustive --inline-suppr -j $$(($$(nproc) / 2)) $(QUIET_FLAG) --std=c99 -D__STDC__ -D__STDC_VERSION__=199901L -U__STRICT_ANSI__ -UFP_NAN -UFP_INFINITE -UFP_ZERO -UFP_SUBNORMAL -UFP_NORMAL -USIZE_T_32 -DWOLFSENTRY_CPPCHECK --suppress=legacyUninitvar --suppress=constParameterPointer  --suppress=constParameterCallback --suppress=unusedStructMember --suppress=variableScope --suppress=knownConditionTrueFalse --suppress=knownArgument --suppress=syntaxError:/usr/\* --suppress=unknownMacro:/usr/\* -I. -I/usr/include -I"$(shell $(CC) -print-file-name=include)" -I"$(LWIP_TOP_FOR_TEST)/src/include" -I"$(SRC_TOP)/ports/Linux-lwIP/include" -UWOLFSENTRY_SEMAPHORE_INCLUDE -UWOLFSENTRY_THREAD_INCLUDE
 
 .PHONY: cppcheck-library
 cppcheck-library:
@@ -300,28 +300,53 @@ c99-test:
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c99-builds" clean
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c99-builds" EXTRA_CFLAGS+='-std=c99 -pedantic' SINGLETHREADED=1
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c99-builds" clean
-	@echo "passed: std=c99 library build tests."
+	@echo "passed: std=c99 tests."
 
 .PHONY: c89-test
 c89-test:
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c89-builds" clean
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c89-builds" EXTRA_CFLAGS+='-std=c89 -pedantic -DWOLFSENTRY_C89 -Wno-variadic-macros -Wno-overlength-strings' test
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c89-builds" clean
-	@echo "passed: std=c89 library build tests."
+	@echo "passed: std=c89 tests."
+
+.PHONY: c23-test
+c23-test:
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c23-builds" clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c23-builds" CC=gcc-15 EXTRA_CFLAGS+='-std=c23 -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE=1 -pedantic -Wno-overlength-strings -Wno-unterminated-string-initialization' test
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c23-builds" clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c23-builds" CC=clang EXTRA_CFLAGS+='-std=c23 -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE=1 -pedantic -Wno-overlength-strings' test
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-c23-builds" clean
+	@echo "passed: std=c23 tests."
 
 .PHONY: m32-test
 m32-test:
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-builds" clean
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-builds" EXTRA_CFLAGS+='-m32' EXTRA_LDFLAGS+=-m32 test
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-builds" clean
-	@echo "passed: -m32 test."
+	@echo "passed: m32 test."
 
 .PHONY: m32-c89-test
 m32-c89-test:
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c89-builds" clean
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c89-builds" EXTRA_CFLAGS+='-m32 -std=c89 -pedantic -DWOLFSENTRY_C89 -Wno-variadic-macros -Wno-overlength-strings' EXTRA_LDFLAGS+=-m32 test
 	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c89-builds" clean
-	@echo "passed: -m32-c89 test."
+	@echo "passed: m32-c89 test."
+
+.PHONY: m32-c23-test
+m32-c23-test:
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c23-builds" clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c23-builds" CC=gcc-15 EXTRA_CFLAGS+='-m32 -std=c23 -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE=1 -pedantic -Wno-overlength-strings -Wno-unterminated-string-initialization' test
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c23-builds" clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c23-builds" CC=clang EXTRA_CFLAGS+='-m32 -std=c23 -D_XOPEN_SOURCE=700 -D_DEFAULT_SOURCE=1 -pedantic -Wno-overlength-strings' test
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-m32-c23-builds" clean
+	@echo "passed: m32-c23 tests."
+
+.PHONY: fortify-source-test
+fortify-source-test:
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-fortify-source-builds" clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-fortify-source-builds" EXTRA_CFLAGS+='-flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -pedantic -DWOLFSENTRY_PEDANTIC_C -Wno-overlength-strings -Wno-unterminated-string-initialization -Wno-inline' EXTRA_LDFLAGS='-Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -Wl,--build-id=sha1 ' test
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-fortify-source-builds" clean
+	@echo "passed: fortify-source tests."
 
 .PHONY: CALL_TRACE-test
 CALL_TRACE-test:
@@ -541,6 +566,24 @@ else
     LWIP_TOP_FOR_TEST := $(SRC_TOP)/../third/lwip
 endif
 
+.PHONY: freertos-arm32-thumb-build-test
+freertos-arm32-thumb-build-test:
+	@[ -d $(FREERTOS_TOP_FOR_TEST)/FreeRTOS/Source/. ] || ( echo '$@: $(FREERTOS_TOP_FOR_TEST)/FreeRTOS/Source not found.' >&2; exit 1)
+	@[ -d $(LWIP_TOP_FOR_TEST)/. ] || ( echo '$@: $(LWIP_TOP_FOR_TEST) not found.' >&2; exit 1)
+	@command -v arm-none-eabi-gcc >/dev/null || ( echo '$@: arm-none-eabi-gcc not found.' >&2; exit 1)
+	@rm -rf "$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds"
+#	first build without FUNCTION_SECTIONS=1 to detect any bloat or unresolved symbols anywhere in the library.
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7 -specs=nano.specs -Wno-inline' NO_STDIO_STREAMS=1 '$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds/tests/test_lwip' UNITTEST_LIST=test_lwip OPTIM='-Os' STRIPPED=1
+	@TEST_LWIP_SZ=$$(stat --format='%s' '$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds/tests/test_lwip'); if [[ "$$TEST_LWIP_SZ" -gt 230000 ]]; then echo "$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds/tests/test_lwip is unexpectedly large ($$TEST_LWIP_SZ bytes)."; exit 1; fi
+	@rm -rf '$(BUILD_PARENT)/'wolfsentry-freertos-arm32-thumb-test-builds/tests/{freertos,lwip}
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7' UNITTEST_LIST=test_lwip clean
+#	now rebuild with FUNCTION_SECTIONS=1, to test expected text size on a parsimonious link.
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7 -specs=nano.specs -Wno-inline' NO_STDIO_STREAMS=1 '$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds/tests/test_lwip' UNITTEST_LIST=test_lwip OPTIM='-Os' STRIPPED=1 FUNCTION_SECTIONS=1
+	@TEST_LWIP_SZ=$$(stat --format='%s' '$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds/tests/test_lwip'); if [[ "$$TEST_LWIP_SZ" -gt 100000 ]]; then echo "$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds/tests/test_lwip is unexpectedly large ($$TEST_LWIP_SZ bytes)."; exit 1; fi
+	@rm -rf '$(BUILD_PARENT)/'wolfsentry-freertos-arm32-thumb-test-builds/tests/{freertos,lwip}
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-thumb-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7' UNITTEST_LIST=test_lwip clean
+	@echo "passed: freertos-arm32-thumb-build test."
+
 .PHONY: freertos-arm32-build-test
 freertos-arm32-build-test:
 	@[ -d $(FREERTOS_TOP_FOR_TEST)/FreeRTOS/Source/. ] || ( echo '$@: $(FREERTOS_TOP_FOR_TEST)/FreeRTOS/Source not found.' >&2; exit 1)
@@ -548,15 +591,15 @@ freertos-arm32-build-test:
 	@command -v arm-none-eabi-gcc >/dev/null || ( echo '$@: arm-none-eabi-gcc not found.' >&2; exit 1)
 	@rm -rf "$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds"
 #	first build without FUNCTION_SECTIONS=1 to detect any bloat or unresolved symbols anywhere in the library.
-	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7 -specs=nano.specs -Wno-inline' NO_STDIO_STREAMS=1 '$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip' UNITTEST_LIST=test_lwip OPTIM='-Os' STRIPPED=1
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mcpu=cortex-m3 -specs=nano.specs -Wno-inline' NO_STDIO_STREAMS=1 '$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip' UNITTEST_LIST=test_lwip OPTIM='-Os' STRIPPED=1
 	@TEST_LWIP_SZ=$$(stat --format='%s' '$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip'); if [[ "$$TEST_LWIP_SZ" -gt 230000 ]]; then echo "$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip is unexpectedly large ($$TEST_LWIP_SZ bytes)."; exit 1; fi
 	@rm -rf '$(BUILD_PARENT)/'wolfsentry-freertos-arm32-test-builds/tests/{freertos,lwip}
-	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7' UNITTEST_LIST=test_lwip clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mcpu=cortex-m3' UNITTEST_LIST=test_lwip clean
 #	now rebuild with FUNCTION_SECTIONS=1, to test expected text size on a parsimonious link.
-	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7 -specs=nano.specs -Wno-inline' NO_STDIO_STREAMS=1 '$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip' UNITTEST_LIST=test_lwip OPTIM='-Os' STRIPPED=1 FUNCTION_SECTIONS=1
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mcpu=cortex-m3 -specs=nano.specs -Wno-inline' NO_STDIO_STREAMS=1 '$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip' UNITTEST_LIST=test_lwip OPTIM='-Os' STRIPPED=1 FUNCTION_SECTIONS=1
 	@TEST_LWIP_SZ=$$(stat --format='%s' '$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip'); if [[ "$$TEST_LWIP_SZ" -gt 100000 ]]; then echo "$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds/tests/test_lwip is unexpectedly large ($$TEST_LWIP_SZ bytes)."; exit 1; fi
 	@rm -rf '$(BUILD_PARENT)/'wolfsentry-freertos-arm32-test-builds/tests/{freertos,lwip}
-	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mthumb -mcpu=cortex-m7' UNITTEST_LIST=test_lwip clean
+	@$(MAKE) $(EXTRA_MAKE_FLAGS) $(QUIET_FLAG) -f $(THIS_MAKEFILE) VERY_QUIET=1 BUILD_TOP="$(BUILD_PARENT)/wolfsentry-freertos-arm32-test-builds" HOST=arm-none-eabi RUNTIME=FreeRTOS-lwIP FREERTOS_TOP=$(FREERTOS_TOP_FOR_TEST) LWIP_TOP=$(LWIP_TOP_FOR_TEST) EXTRA_CFLAGS+='-mcpu=cortex-m3' UNITTEST_LIST=test_lwip clean
 	@echo "passed: freertos-arm32-build test."
 
 .PHONY: freertos-arm32-singlethreaded-build-test
@@ -782,7 +825,7 @@ doc-check:
 check: dynamic-build-test c99-test no-alloca-test singlethreaded-test no-json-test no-json-dom-test no-error-strings-test no-protocol-names-test no-getprotoby-test no-stdio-streams-build-test minimal-build-test minimal-threaded-build-test user-settings-build-test short-enums-test no-addr-bitmask-matching-test no-ipv6-test
 
 .PHONY: check-extra
-check-extra: library-dependency-singlethreaded-build-test library-dependency-multithreaded-build-test pahole-test route-holes-test static-build-test c89-test no-inline-test m32-test m32-c89-test CALL_TRACE-test small-PRIVATE_DATA_ALIGNMENT-test big-PRIVATE_DATA_ALIGNMENT-test HPI_POSIX_VANILLA-test freertos-arm32-build-test freertos-arm32-singlethreaded-build-test freertos-arm32-c89-build-test linux-lwip-test linux-lwip-test-no-ipv6 linux-lwip-c89-m32-test dist-check release-check doc-check notification-demo-build-test .WAIT benchmark-test benchmark-singlethreaded-test
+check-extra: library-dependency-singlethreaded-build-test library-dependency-multithreaded-build-test pahole-test route-holes-test static-build-test c89-test c23-test no-inline-test m32-test m32-c89-test m32-c23-test fortify-source-test CALL_TRACE-test small-PRIVATE_DATA_ALIGNMENT-test big-PRIVATE_DATA_ALIGNMENT-test HPI_POSIX_VANILLA-test freertos-arm32-thumb-build-test freertos-arm32-build-test freertos-arm32-singlethreaded-build-test freertos-arm32-c89-build-test linux-lwip-test linux-lwip-test-no-ipv6 linux-lwip-c89-m32-test dist-check release-check doc-check notification-demo-build-test .WAIT benchmark-test benchmark-singlethreaded-test
 
 ifdef JSON_TEST_CORPUS_DIR
 export JSON_TEST_CORPUS_DIR

--- a/src/addr_families.c
+++ b/src/addr_families.c
@@ -264,10 +264,11 @@ static wolfsentry_errcode_t wolfsentry_addr_family_get_byname_1(
     struct wolfsentry_addr_family_bynumber **addr_family)
 {
     wolfsentry_errcode_t ret;
-    struct {
-        struct wolfsentry_addr_family_byname target;
-        byte buf[WOLFSENTRY_MAX_LABEL_BYTES];
-    } target;
+    WOLFSENTRY_STACKBUF(
+        struct wolfsentry_addr_family_byname,
+        name,
+        WOLFSENTRY_MAX_LABEL_BYTES,
+        target);
 
     struct wolfsentry_addr_family_byname *addr_family_1 = &target.target;
 

--- a/src/json/centijson_value.c
+++ b/src/json/centijson_value.c
@@ -839,7 +839,7 @@ json_value_string(const JSON_VALUE* v)
 WOLFSENTRY_API size_t
 json_value_string_length(const JSON_VALUE* v)
 {
-    uint8_t* payload;
+    const uint8_t* payload;
     size_t off = 0;
     size_t len = 0;
     unsigned shift = 0;

--- a/src/json/load_config.c
+++ b/src/json/load_config.c
@@ -1902,9 +1902,11 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_config_json_feed(
         WOLFSENTRY_SET_BITS(jps->load_flags, WOLFSENTRY_CONFIG_LOAD_FLAG_FINI);
         if (err_buf) {
             if (WOLFSENTRY_ERROR_DECODE_SOURCE_ID(jps->fini_ret) == WOLFSENTRY_SOURCE_ID_UNSET)
-                snprintf(err_buf, err_buf_size, "json_feed failed at offset %d, line %u, col %u, with centijson code " WOLFSENTRY_ERRCODE_FMT ": %s", (int)json_pos.offset, json_pos.line_number, json_pos.column_number, (int)jps->fini_ret, json_error_str(jps->fini_ret));
+                ret = snprintf(err_buf, err_buf_size, "json_feed failed at offset %d, line %u, col %u, with centijson code " WOLFSENTRY_ERRCODE_FMT ": %s", (int)json_pos.offset, json_pos.line_number, json_pos.column_number, (int)jps->fini_ret, json_error_str(jps->fini_ret));
             else
-                snprintf(err_buf, err_buf_size, "json_feed failed at offset %d, line %u, col %u, with " WOLFSENTRY_ERROR_FMT, (int)json_pos.offset, json_pos.line_number, json_pos.column_number, WOLFSENTRY_ERROR_FMT_ARGS(jps->fini_ret));
+                ret = snprintf(err_buf, err_buf_size, "json_feed failed at offset %d, line %u, col %u, with " WOLFSENTRY_ERROR_FMT, (int)json_pos.offset, json_pos.line_number, json_pos.column_number, WOLFSENTRY_ERROR_FMT_ARGS(jps->fini_ret));
+            if (ret >= (int)err_buf_size)
+                err_buf[err_buf_size - 1] = 0;
         }
         WOLFSENTRY_ERROR_RERETURN(wolfsentry_centijson_errcode_translate(jps->fini_ret));
     }
@@ -1941,9 +1943,14 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_config_json_fini(
     } else {
         (*jps)->fini_ret = json_fini(&(*jps)->parser, &json_pos);
         if ((*jps)->fini_ret < 0) {
-            if (err_buf != NULL)
-                snprintf(err_buf, err_buf_size, "json_fini failed at offset %d, line %u, col %u, with code " WOLFSENTRY_ERRCODE_FMT ": %s.",
-                         (int)json_pos.offset,json_pos.line_number, json_pos.column_number, (int)(*jps)->fini_ret, json_error_str((*jps)->fini_ret));
+            if (err_buf != NULL) {
+                if (snprintf(err_buf, err_buf_size, "json_fini failed at offset %d, line %u, col %u, with code " WOLFSENTRY_ERRCODE_FMT ": %s.",
+                             (int)json_pos.offset,json_pos.line_number, json_pos.column_number, (int)(*jps)->fini_ret, json_error_str((*jps)->fini_ret))
+                    >= (int)err_buf_size)
+                {
+                    err_buf[err_buf_size - 1] = 0;
+                }
+            }
             ret = wolfsentry_centijson_errcode_translate((*jps)->fini_ret);
             goto out;
         }

--- a/src/wolfsentry_util.c
+++ b/src/wolfsentry_util.c
@@ -4056,7 +4056,7 @@ WOLFSENTRY_API wolfsentry_hitcount_t wolfsentry_table_n_deletes(struct wolfsentr
     WOLFSENTRY_RETURN_VALUE(table->n_deletes);
 }
 
-static const char base64_inv_lut[0x100] =
+static const char base64_inv_lut[0x101] =
     /* ^@-\x1f */ "||||||||||||||||||||||||||||||||"
     /* \ -* */ "|||||||||||"
     /* + */ "\x3e"

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -461,7 +461,7 @@ static __attribute_maybe_unused__ wolfsentry_errcode_t json_feed_file(WOLFSENTRY
     if (strcmp(fname,"-")) {
         f = fopen(fname, "r");
         if (! f) {
-            fprintf(stderr, "fopen(%s): %s\n",fname,strerror(errno));
+            (void)fprintf(stderr, "fopen(%s): %s\n",fname,strerror(errno));
             WOLFSENTRY_ERROR_RETURN(UNIT_TEST_FAILURE);
         }
     }
@@ -473,7 +473,7 @@ static __attribute_maybe_unused__ wolfsentry_errcode_t json_feed_file(WOLFSENTRY
     for (;;) {
         size_t n = fread(buf, 1, sizeof buf, f ? f : stdin);
         if ((n < sizeof buf) && ferror(f)) {
-            fprintf(stderr,"fread(%s): %s\n",fname, strerror(errno));
+            (void)fprintf(stderr,"fread(%s): %s\n",fname, strerror(errno));
             ret = WOLFSENTRY_ERROR_ENCODE(UNIT_TEST_FAILURE);
             goto out;
         }
@@ -481,7 +481,7 @@ static __attribute_maybe_unused__ wolfsentry_errcode_t json_feed_file(WOLFSENTRY
         ret = wolfsentry_config_json_feed(jps, buf, n, err_buf, sizeof err_buf);
         if (ret < 0) {
             if (verbose)
-                fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
+                (void)fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
             goto out;
         }
         if ((n < sizeof buf) && feof(f))
@@ -493,7 +493,7 @@ static __attribute_maybe_unused__ wolfsentry_errcode_t json_feed_file(WOLFSENTRY
     fini_ret = wolfsentry_config_json_fini(&jps, err_buf, sizeof err_buf);
     if (fini_ret < 0) {
         if (verbose)
-            fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
+            (void)fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
     }
     if (WOLFSENTRY_ERROR_CODE_IS(ret, OK))
         ret = fini_ret;
@@ -504,7 +504,7 @@ static __attribute_maybe_unused__ wolfsentry_errcode_t json_feed_file(WOLFSENTRY
         fclose(f);
 
     if ((ret < 0) && verbose)
-        fprintf(stderr,"error processing file %s\n",fname);
+        (void)fprintf(stderr,"error processing file %s\n",fname);
 
     WOLFSENTRY_ERROR_RERETURN(ret);
 }
@@ -1122,9 +1122,9 @@ usleep(10000);
         (measured_sequence[7] != 8)) {
     // GCOV_EXCL_START
         size_t i;
-        fprintf(stderr,"wrong sequence at L%d.  should be {3,7,1,2,5,6,4,8} (the middle 4 are safely permutable), but got {", __LINE__);
+        (void)fprintf(stderr,"wrong sequence at L%d.  should be {3,7,1,2,5,6,4,8} (the middle 4 are safely permutable), but got {", __LINE__);
         for (i = 0; i < sizeof measured_sequence / sizeof measured_sequence[0]; ++i)
-            fprintf(stderr,"%d%s",measured_sequence[i], i == (sizeof measured_sequence / sizeof measured_sequence[0]) - 1 ? "}.\n" : ",");
+            (void)fprintf(stderr,"%d%s",measured_sequence[i], i == (sizeof measured_sequence / sizeof measured_sequence[0]) - 1 ? "}.\n" : ",");
         WOLFSENTRY_ERROR_RETURN(NOT_OK);
     // GCOV_EXCL_STOP
     }
@@ -1206,9 +1206,9 @@ usleep(10000);
         (SEQ(8) - SEQ(4) != 1)) {
     // GCOV_EXCL_START
         size_t i;
-        fprintf(stderr,"wrong sequence at L%d.  got {", __LINE__);
+        (void)fprintf(stderr,"wrong sequence at L%d.  got {", __LINE__);
         for (i = 0; i < sizeof measured_sequence / sizeof measured_sequence[0]; ++i)
-            fprintf(stderr,"%d%s",measured_sequence[i], i == (sizeof measured_sequence / sizeof measured_sequence[0]) - 1 ? "}.\n" : ",");
+            (void)fprintf(stderr,"%d%s",measured_sequence[i], i == (sizeof measured_sequence / sizeof measured_sequence[0]) - 1 ? "}.\n" : ",");
         WOLFSENTRY_ERROR_RETURN(NOT_OK);
     // GCOV_EXCL_STOP
     }
@@ -1295,9 +1295,9 @@ usleep(10000);
         (SEQ(8) - SEQ(4) != 1)) {
     // GCOV_EXCL_START
         size_t i;
-        fprintf(stderr,"wrong sequence at L%d.  got {", __LINE__);
+        (void)fprintf(stderr,"wrong sequence at L%d.  got {", __LINE__);
         for (i = 0; i < sizeof measured_sequence / sizeof measured_sequence[0]; ++i)
-            fprintf(stderr,"%d%s",measured_sequence[i], i == (sizeof measured_sequence / sizeof measured_sequence[0]) - 1 ? "}.\n" : ",");
+            (void)fprintf(stderr,"%d%s",measured_sequence[i], i == (sizeof measured_sequence / sizeof measured_sequence[0]) - 1 ? "}.\n" : ",");
         WOLFSENTRY_ERROR_RETURN(NOT_OK);
     // GCOV_EXCL_STOP
     }
@@ -1530,7 +1530,7 @@ static int test_static_routes(void) {
         printf("benchmark wolfsentry_route_event_dispatch() with empty route table: %.2f ns/call %.2f cycles/call\n", ns_per_call, cycles_per_call);
 #ifdef WOLFSENTRY_MAX_CYCLES_PER_CALL_EMPTY_TABLE
 	if (cycles_per_call > (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_EMPTY_TABLE) {
-            fprintf(stderr, "benchmark wolfsentry_route_event_dispatch() with empty route table: measured %.2f cycles/call exceeds max %.2f\n", cycles_per_call, (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_EMPTY_TABLE);
+            (void)fprintf(stderr, "benchmark wolfsentry_route_event_dispatch() with empty route table: measured %.2f cycles/call exceeds max %.2f\n", cycles_per_call, (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_EMPTY_TABLE);
             WOLFSENTRY_EXIT_ON_TRUE(cycles_per_call > (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_EMPTY_TABLE);
         }
 #endif
@@ -1768,7 +1768,7 @@ static int test_static_routes(void) {
     WOLFSENTRY_SET_BITS(flags_wildcard, WOLFSENTRY_ROUTE_FLAG_SA_REMOTE_PORT_WILDCARD);
 
     {
-        struct wolfsentry_route *new_route;
+        struct wolfsentry_route *new_route = NULL;
 
         WOLFSENTRY_EXIT_ON_FAILURE(wolfsentry_route_insert_and_check_out(WOLFSENTRY_CONTEXT_ARGS_OUT, NULL /* caller_arg */, &remote_wildcard.sa, &local_wildcard.sa, flags_wildcard, 0 /* event_label_len */, 0 /* event_label */, &new_route, &action_results));
 
@@ -3994,7 +3994,7 @@ static int test_json(const char *fname, const char *extra_fname) {
             err_buf,
             sizeof err_buf);
         if (ret < 0) {
-            fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
+            (void)fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
             WOLFSENTRY_EXIT_ON_FAILURE(ret);
         }
 
@@ -4047,7 +4047,7 @@ static int test_json(const char *fname, const char *extra_fname) {
             err_buf,
             sizeof err_buf);
         if (ret < 0) {
-            fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
+            (void)fprintf(stderr, "%.*s\n", (int)sizeof err_buf, err_buf);
             WOLFSENTRY_EXIT_ON_FAILURE(ret);
         }
 
@@ -4169,7 +4169,7 @@ static int test_json(const char *fname, const char *extra_fname) {
                 val_type = "?";
             if (wolfsentry_kv_render_value(WOLFSENTRY_CONTEXT_ARGS_OUT, kv_exports, val_buf, &val_buf_space) < 0) {
                 if (WOLFSENTRY_KV_TYPE(kv_exports) == WOLFSENTRY_KV_BYTES)
-                    snprintf(val_buf, sizeof val_buf, "<%.*s>", (int)WOLFSENTRY_KV_V_BYTES_LEN(kv_exports), WOLFSENTRY_KV_V_BYTES(kv_exports));
+                    (void)snprintf(val_buf, sizeof val_buf, "<%.*s>", (int)WOLFSENTRY_KV_V_BYTES_LEN(kv_exports), WOLFSENTRY_KV_V_BYTES(kv_exports));
                 else
                     strcpy(val_buf,"?");
             }
@@ -4465,10 +4465,10 @@ static int test_json(const char *fname, const char *extra_fname) {
             int linelen = p ? ((int)((unsigned char *)p - (test_json_document + json_pos.offset)) + (int)json_pos.column_number - 1) :
                 (((int)st.st_size - (int)json_pos.offset) + (int)json_pos.column_number - 1);
             if (WOLFSENTRY_ERROR_DECODE_SOURCE_ID(ret) == WOLFSENTRY_SOURCE_ID_UNSET)
-                fprintf(stderr, "json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with centijson code %d: %s\n", json_pos.offset,json_pos.line_number, json_pos.column_number, ret, json_dom_error_str(ret));
+                (void)fprintf(stderr, "json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with centijson code %d: %s\n", json_pos.offset,json_pos.line_number, json_pos.column_number, ret, json_dom_error_str(ret));
             else
-                fprintf(stderr, "json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with " WOLFSENTRY_ERROR_FMT "\n", json_pos.offset,json_pos.line_number, json_pos.column_number, WOLFSENTRY_ERROR_FMT_ARGS(ret));
-            fprintf(stderr,"%.*s\n", linelen, test_json_document + json_pos.offset - json_pos.column_number + 1);
+                (void)fprintf(stderr, "json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with " WOLFSENTRY_ERROR_FMT "\n", json_pos.offset,json_pos.line_number, json_pos.column_number, WOLFSENTRY_ERROR_FMT_ARGS(ret));
+            (void)fprintf(stderr,"%.*s\n", linelen, test_json_document + json_pos.offset - json_pos.column_number + 1);
             exit(1);
         }
 
@@ -4715,7 +4715,7 @@ static int test_json(const char *fname, const char *extra_fname) {
 
 #ifdef WOLFSENTRY_MAX_CYCLES_PER_CALL_JSON_LOADED
 	if (cycles_per_call > (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_JSON_LOADED) {
-            fprintf(stderr, "benchmark wolfsentry_route_event_dispatch_with_inited_result() with JSON-loaded route table, matching penalty-boxed route: measured %.2f cycles/call exceeds max %.2f\n", cycles_per_call, (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_JSON_LOADED);
+            (void)fprintf(stderr, "benchmark wolfsentry_route_event_dispatch_with_inited_result() with JSON-loaded route table, matching penalty-boxed route: measured %.2f cycles/call exceeds max %.2f\n", cycles_per_call, (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_JSON_LOADED);
             WOLFSENTRY_EXIT_ON_TRUE(cycles_per_call > (double)WOLFSENTRY_MAX_CYCLES_PER_CALL_JSON_LOADED);
         }
 #endif
@@ -4987,7 +4987,7 @@ static int test_json_corpus(void) {
                     }
                 }
                 if (i == sizeof centijson_flag_map / sizeof centijson_flag_map[0]) {
-                    fprintf(stderr, "unrecognized flag \"%.*s\" in JSON_TEST_CORPUS_FLAGS.\n", (int)label_len, cp);
+                    (void)fprintf(stderr, "unrecognized flag \"%.*s\" in JSON_TEST_CORPUS_FLAGS.\n", (int)label_len, cp);
                     exit(1);
                 }
                 cp += label_len;
@@ -5047,10 +5047,10 @@ static int test_json_corpus(void) {
                 int linelen = p ? ((int)((unsigned char *)p - (scenario + json_pos.offset)) + (int)json_pos.column_number - 1) :
                     (((int)st.st_size - (int)json_pos.offset) + (int)json_pos.column_number - 1);
                 if (WOLFSENTRY_ERROR_DECODE_SOURCE_ID(ret) == WOLFSENTRY_SOURCE_ID_UNSET)
-                    fprintf(stderr, "%s/%s: json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with centijson code %d: %s\n", corpus_path, scenario_ent->d_name, json_pos.offset,json_pos.line_number, json_pos.column_number, ret, json_dom_error_str(ret));
+                    (void)fprintf(stderr, "%s/%s: json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with centijson code %d: %s\n", corpus_path, scenario_ent->d_name, json_pos.offset,json_pos.line_number, json_pos.column_number, ret, json_dom_error_str(ret));
                 else
-                    fprintf(stderr, "%s/%s: json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with " WOLFSENTRY_ERROR_FMT "\n", corpus_path, scenario_ent->d_name, json_pos.offset,json_pos.line_number, json_pos.column_number, WOLFSENTRY_ERROR_FMT_ARGS(ret));
-                fprintf(stderr,"%.*s\n", linelen, scenario + json_pos.offset - json_pos.column_number + 1);
+                    (void)fprintf(stderr, "%s/%s: json_dom_parse failed at offset " SIZET_FMT ", L%u, col %u, with " WOLFSENTRY_ERROR_FMT "\n", corpus_path, scenario_ent->d_name, json_pos.offset,json_pos.line_number, json_pos.column_number, WOLFSENTRY_ERROR_FMT_ARGS(ret));
+                (void)fprintf(stderr,"%.*s\n", linelen, scenario + json_pos.offset - json_pos.column_number + 1);
                 goto inner_cleanup;
             }
 
@@ -5127,7 +5127,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_INIT
     ret = test_init();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_init failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_init failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5139,7 +5139,7 @@ int main(int argc, char* argv[]) {
     ret = test_lwip(NULL);
     #endif
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_lwip failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_lwip failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5147,7 +5147,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_RWLOCKS
     ret = test_rw_locks();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_rw_locks failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_rw_locks failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5155,7 +5155,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_STATIC_ROUTES
     ret = test_static_routes();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_static_routes failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_static_routes failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5163,7 +5163,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_DYNAMIC_RULES
     ret = test_dynamic_rules();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_dynamic_rules failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_dynamic_rules failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5171,7 +5171,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_USER_VALUES
     ret = test_user_values();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_user_values failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_user_values failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5179,7 +5179,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_USER_ADDR_FAMILIES
     ret = test_user_addr_families();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_addr_families failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_addr_families failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5192,13 +5192,13 @@ int main(int argc, char* argv[]) {
     ret = test_json(TEST_JSON_CONFIG_PATH, NULL);
 #endif
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_json failed for " TEST_JSON_CONFIG_PATH ", " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_json failed for " TEST_JSON_CONFIG_PATH ", " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
     ret = test_json(TEST_NUMERIC_JSON_CONFIG_PATH, NULL);
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_json failed for " TEST_NUMERIC_JSON_CONFIG_PATH ", " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_json failed for " TEST_NUMERIC_JSON_CONFIG_PATH ", " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif
@@ -5206,7 +5206,7 @@ int main(int argc, char* argv[]) {
 #ifdef TEST_JSON_CORPUS
     ret = test_json_corpus();
     if (! WOLFSENTRY_ERROR_CODE_IS(ret, OK)) {
-        fprintf(stderr, "test_json_corpus failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
+        (void)fprintf(stderr, "test_json_corpus failed, " WOLFSENTRY_ERROR_FMT "\n", WOLFSENTRY_ERROR_FMT_ARGS(ret));
         err = 1;
     }
 #endif

--- a/wolfsentry/wolfsentry_settings.h
+++ b/wolfsentry/wolfsentry_settings.h
@@ -154,7 +154,7 @@
  */
 
 #if !defined(WOLFSENTRY_NO_STDIO_STREAMS) && !defined(WOLFSENTRY_PRINTF_ERR)
-    #define WOLFSENTRY_PRINTF_ERR(...) fprintf(stderr, __VA_ARGS__)
+    #define WOLFSENTRY_PRINTF_ERR(...) (void)fprintf(stderr, __VA_ARGS__)
         /*!< \brief printf-like macro, expecting a format as first arg, used for rendering warning and error messages.  Can be overridden in #WOLFSENTRY_USER_SETTINGS_FILE. @hideinitializer */
 #endif
 
@@ -324,13 +324,23 @@
         /*!< \brief Define if `posix_memalign()` is not available. */
 #endif
 
-#if defined(__STRICT_ANSI__)
-#define WOLFSENTRY_FLEXIBLE_ARRAY_SIZE 1
+#if defined(WOLFSENTRY_FLEXIBLE_ARRAY_SIZE)
+    /* keep override value. */
+#elif defined(__STRICT_ANSI__) || defined(WOLFSENTRY_PEDANTIC_C)
+    #define WOLFSENTRY_FLEXIBLE_ARRAY_SIZE 1
 #elif defined(__GNUC__) && !defined(__clang__)
-#define WOLFSENTRY_FLEXIBLE_ARRAY_SIZE
+    #define WOLFSENTRY_FLEXIBLE_ARRAY_SIZE
     /*!< \brief Value appropriate as a size for an array that will be allocated to a variable size.  Built-in value usually works. */
 #else
-#define WOLFSENTRY_FLEXIBLE_ARRAY_SIZE 0
+    #define WOLFSENTRY_FLEXIBLE_ARRAY_SIZE 0
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__) && !defined(WOLFSENTRY_NO_PRAGMAS)
+    #define WOLFSENTRY_GCC_PRAGMAS
+#endif
+
+#if defined(__clang__) && !defined(WOLFSENTRY_NO_PRAGMAS)
+    #define WOLFSENTRY_CLANG_PRAGMAS
 #endif
 
 /*! @cond doxygen_all */

--- a/wolfsentry/wolfsentry_util.h
+++ b/wolfsentry/wolfsentry_util.h
@@ -117,6 +117,20 @@
 #define WOLFSENTRY_CLEAR_ALL_BITS(enumint) ((enumint) = 0)
    /*!< \brief Clears all bits in `enumint`.  @hideinitializer */
 
+#if defined(__STRICT_ANSI__) || defined(WOLFSENTRY_PEDANTIC_C) || \
+    ((WOLFSENTRY_FLEXIBLE_ARRAY_SIZE + 0) > 0)
+    #define WOLFSENTRY_STACKBUF_MINBUF 1
+#else
+    #define WOLFSENTRY_STACKBUF_MINBUF 0
+#endif
+
+#define WOLFSENTRY_STACKBUF(type, flex_slot, buf_size, buf_name) struct {  \
+        type buf_name;                                                     \
+        byte buf[(buf_size) > (sizeof(type) - offsetof(type, flex_slot)) ? \
+                 (buf_size) - (sizeof(type) - offsetof(type, flex_slot)) : \
+                 WOLFSENTRY_STACKBUF_MINBUF];                              \
+    } buf_name
+
 #ifndef BITS_PER_BYTE
 #define BITS_PER_BYTE 8
 #endif


### PR DESCRIPTION
update for LLVM-20, gcc-15, and cppcheck-2.14.2;

add `c23-test`, `m32-c23-test`, `fortify-source-test`, `freertos-arm32-build-test`;

add `WOLFSENTRY_STACKBUF()` and use it to refactor on-stack flexible-element struct instances.

tested with `make check-all`
