### PR TITLE
Support for ThreadX and NetX Duo

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ topic.
 | `DEBUG` | | Compiler debugging flag to use (default `-ggdb`) |
 | `OPTIM` | | The optimizer flag to use (default `-O3`) |
 | `HOST` | | The target host tuple, for cross-compilation (default unset, i.e. native targeting) |
-| `RUNTIME` | | The target runtime ecosystem -- default unset, `FreeRTOS-lwIP` and `Linux-lwIP` are recognized |
+| `RUNTIME` | | The target runtime ecosystem -- default unset, `FreeRTOS-lwIP`, `Linux-lwIP` and `ThreadX-NetXDuo` are recognized |
 | `C_WARNFLAGS` | | The warning flags to use (overriding the generally applicable defaults) |
 | `STATIC` | | Build statically linked unit tests |
 | `STRIPPED` | | Strip binaries of debugging symbols |

--- a/src/json/load_config.c
+++ b/src/json/load_config.c
@@ -33,6 +33,8 @@
 
 #ifdef WOLFSENTRY_LWIP
 #include "lwip/sockets.h"
+#elif defined(WOLFSENTRY_NETXDUO)
+#include "wolfsentry/wolfsentry_netxduo.h"
 #else
 #include <arpa/inet.h>
 #include <sys/socket.h>
@@ -1294,7 +1296,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             WOLFSENTRY_ERROR_RERETURN(ret);
         case JSON_FALSE:
             ret = wolfsentry_user_value_store_bool(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->cur_keyname,
                 WOLFSENTRY_LENGTH_NULL_TERMINATED,
                 WOLFSENTRY_KV_FALSE,
@@ -1303,7 +1305,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             WOLFSENTRY_ERROR_RERETURN(ret);
         case JSON_TRUE:
             ret = wolfsentry_user_value_store_bool(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->cur_keyname,
                 WOLFSENTRY_LENGTH_NULL_TERMINATED,
                 WOLFSENTRY_KV_TRUE,
@@ -1316,7 +1318,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
                 if ((ret = convert_sint64(json_type, data, data_size, &i)) < 0)
                     break;
                 ret = wolfsentry_user_value_store_sint(
-                    JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                    JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                     jps->cur_keyname,
                     WOLFSENTRY_LENGTH_NULL_TERMINATED,
                     i,
@@ -1327,7 +1329,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
                 if ((ret = convert_double(json_type, data, data_size, &d)) < 0)
                     WOLFSENTRY_ERROR_RERETURN(ret);
                 ret = wolfsentry_user_value_store_double(
-                    JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                    JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                     jps->cur_keyname,
                     WOLFSENTRY_LENGTH_NULL_TERMINATED,
                     d,
@@ -1339,7 +1341,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             if (data_size >= WOLFSENTRY_KV_MAX_VALUE_BYTES)
                 WOLFSENTRY_ERROR_RETURN(STRING_ARG_TOO_LONG);
             ret = wolfsentry_user_value_store_string(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->cur_keyname,
                 WOLFSENTRY_LENGTH_NULL_TERMINATED,
                 (const char *)data,
@@ -1454,7 +1456,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             if ((ret = convert_sint64(json_type, data, data_size, &i)) < 0)
                 WOLFSENTRY_ERROR_RERETURN(ret);
             WOLFSENTRY_ERROR_RERETURN(wolfsentry_user_value_store_sint(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->o_u_c.user_value.label,
                 jps->o_u_c.user_value.label_len,
                 i,
@@ -1465,7 +1467,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             if ((ret = convert_double(json_type, data, data_size, &d)) < 0)
                 WOLFSENTRY_ERROR_RERETURN(ret);
             WOLFSENTRY_ERROR_RERETURN(wolfsentry_user_value_store_double(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->o_u_c.user_value.label,
                 jps->o_u_c.user_value.label_len,
                 d,
@@ -1475,7 +1477,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             if (data_size >= WOLFSENTRY_KV_MAX_VALUE_BYTES)
                 WOLFSENTRY_ERROR_RETURN(STRING_ARG_TOO_LONG);
             WOLFSENTRY_ERROR_RERETURN(wolfsentry_user_value_store_string(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->o_u_c.user_value.label,
                 jps->o_u_c.user_value.label_len,
                 (const char *)data,
@@ -1486,7 +1488,7 @@ static wolfsentry_errcode_t handle_user_value_clause(struct wolfsentry_json_proc
             if (data_size >= WOLFSENTRY_KV_MAX_VALUE_BYTES)
                 WOLFSENTRY_ERROR_RETURN(STRING_ARG_TOO_LONG);
             WOLFSENTRY_ERROR_RERETURN(wolfsentry_user_value_store_bytes_base64(
-                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT, 
+                JPS_WOLFSENTRY_CONTEXT_ARGS_OUT,
                 jps->o_u_c.user_value.label,
                 jps->o_u_c.user_value.label_len,
                 (const char *)data,

--- a/src/routes.c
+++ b/src/routes.c
@@ -22,8 +22,6 @@
 
 #define WOLFSENTRY_SOURCE_ID WOLFSENTRY_SOURCE_ID_ROUTES_C
 
-#include "wolfsentry_internal.h"
-
 #ifndef WOLFSENTRY_NO_ALLOCA
 #include <alloca.h>
 #endif
@@ -31,6 +29,8 @@
 #ifdef WOLFSENTRY_LWIP
 #include <lwip/inet.h>
 #include <lwip/sockets.h>
+#elif defined(WOLFSENTRY_NETXDUO)
+#include "wolfsentry/wolfsentry_netxduo.h"
 #else
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -39,6 +39,8 @@
 #ifndef WOLFSENTRY_NO_GETPROTOBY
 #include <netdb.h>
 #endif
+
+#include "wolfsentry_internal.h"
 
 static inline int cmp_addrs_prefixful(
     const byte *left_addr,

--- a/src/wolfsentry_util.c
+++ b/src/wolfsentry_util.c
@@ -1509,6 +1509,73 @@ static int freertos_sem_destroy( sem_t * sem )
 
 #define sem_destroy freertos_sem_destroy
 
+#elif defined(THREADX)
+
+    #ifndef ETIMEDOUT
+        #define ETIMEDOUT       110 /* Connection timed out */
+    #endif
+
+    #define sem_init threadx_sem_init
+    static int threadx_sem_init( sem_t * sem,
+                int pshared,
+                unsigned value )
+    {
+        (void)pshared;
+        if (tx_semaphore_create(sem, NULL, value) != TX_SUCCESS) {
+            errno = EINVAL;
+            WOLFSENTRY_RETURN_VALUE(-1);
+        }
+        WOLFSENTRY_RETURN_VALUE(0);
+    }
+    #define sem_post threadx_sem_post
+    static int threadx_sem_post( sem_t * sem )
+    {
+        if (tx_semaphore_put(sem) != TX_SUCCESS) {
+            errno = EINVAL;
+            WOLFSENTRY_RETURN_VALUE(-1);
+        }
+        WOLFSENTRY_RETURN_VALUE(0);
+    }
+    #define sem_timedwait threadx_sem_timedwait
+    static int threadx_sem_timedwait( sem_t * sem,
+                    const struct timespec * abstime )
+    {
+        if (tx_semaphore_get(sem, (uint32_t)(TX_TICK_TIME_MS *
+            (abstime->tv_sec * 1000) + (abstime->tv_nsec / 1000000))) != TX_SUCCESS) {
+            errno = EINVAL;
+            WOLFSENTRY_RETURN_VALUE(-1);
+        }
+        WOLFSENTRY_RETURN_VALUE(0);
+    }
+    #define sem_wait threadx_sem_wait
+    static int threadx_sem_wait( sem_t * sem )
+    {
+        if (tx_semaphore_get(sem, TX_WAIT_FOREVER) != TX_SUCCESS) {
+            errno = EINVAL;
+            WOLFSENTRY_RETURN_VALUE(-1);
+        }
+        WOLFSENTRY_RETURN_VALUE(0);
+    }
+    #define sem_trywait threadx_sem_trywait
+    static int threadx_sem_trywait( sem_t * sem )
+    {
+        if (tx_semaphore_get(sem, TX_NO_WAIT) != TX_SUCCESS) {
+            errno = EINVAL;
+            WOLFSENTRY_RETURN_VALUE(-1);
+        }
+        WOLFSENTRY_RETURN_VALUE(0);
+    }
+    static int threadx_sem_destroy( sem_t * sem )
+    {
+        if (tx_semaphore_delete(sem) != TX_SUCCESS) {
+            errno = EINVAL;
+            WOLFSENTRY_RETURN_VALUE(-1);
+        }
+        WOLFSENTRY_RETURN_VALUE(0);
+    }
+
+    #define sem_destroy threadx_sem_destroy
+
 #else
 
 #error Semaphore builtins not implemented for target -- build wolfSentry with -DWOLFSENTRY_NO_SEM_BUILTIN, and supply semaphore implementation with struct wolfsentry_host_platform_interface argument to wolfsentry_init().
@@ -2847,7 +2914,7 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_lock_shared2mutex_abstimed(struct
                     WOLFSENTRY_ERROR_RETURN(SYS_OP_FATAL);
             }
         }
-    } else 
+    } else
         ret = sem_timedwait(&lock->sem_read2write_waiters, abs_timeout);
 
     if (ret < 0) {
@@ -3313,6 +3380,19 @@ static wolfsentry_errcode_t wolfsentry_builtin_get_time(void *context, wolfsentr
     struct timespec ts;
     (void)context;
     freertos_now(&ts);
+    *now = ((wolfsentry_time_t)ts.tv_sec * (wolfsentry_time_t)1000000) + ((wolfsentry_time_t)ts.tv_nsec / (wolfsentry_time_t)1000);
+    WOLFSENTRY_RETURN_OK;
+}
+
+#elif defined(THREADX)
+
+static wolfsentry_errcode_t wolfsentry_builtin_get_time(void *context, wolfsentry_time_t *now) {
+    struct timespec ts;
+    uint32_t tick_count;
+    (void)context;
+    tick_count = tx_time_get();
+    ts.tv_sec = (long)tick_count / TX_TICK_TIME_MS;
+    ts.tv_nsec = (long)(tick_count % TX_TICK_TIME_MS) * 1000000;
     *now = ((wolfsentry_time_t)ts.tv_sec * (wolfsentry_time_t)1000000) + ((wolfsentry_time_t)ts.tv_nsec / (wolfsentry_time_t)1000);
     WOLFSENTRY_RETURN_OK;
 }

--- a/tests/unittests.c
+++ b/tests/unittests.c
@@ -69,6 +69,13 @@ int lwip_inet_pton(int af, const char *src, void *dst) {
 
 #endif /* !TEST_LWIP */
 
+#elif defined(WOLFSENTRY_NETXDUO)
+
+#include "nxd_bsd.h"
+/* undef OK this conflicts with the _OK macros in wolfsentry_errcodes.h */
+#undef OK
+
+
 #else /* !WOLFSENTRY_LWIP */
 
 #include <sys/socket.h>

--- a/wolfsentry/wolfsentry.h
+++ b/wolfsentry/wolfsentry.h
@@ -85,9 +85,9 @@ typedef enum {
 /*! @endcond */
 #endif
 
-#include <wolfsentry/wolfsentry_settings.h>
-#include <wolfsentry/wolfsentry_af.h>
-#include <wolfsentry/wolfsentry_errcodes.h>
+#include "wolfsentry/wolfsentry_settings.h"
+#include "wolfsentry/wolfsentry_af.h"
+#include "wolfsentry/wolfsentry_errcodes.h"
 
 struct wolfsentry_allocator;
 struct wolfsentry_context;
@@ -3012,7 +3012,7 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_event_action_list_done(
 /*! @} (end wolfsentry_event) */
 
 #ifdef WOLFSENTRY_HAVE_JSON_DOM
-#include <wolfsentry/centijson_dom.h>
+#include "wolfsentry/centijson_dom.h"
 #endif
 
 /*! \addtogroup wolfsentry_kv
@@ -3345,7 +3345,7 @@ WOLFSENTRY_API int wolfsentry_inet6_ntoa(const byte *addr, unsigned int addr_bit
     (((((len)+3)/4)*3) - ((len) > 1 ? \
                           ((buf)[(len)-1] == '=') : \
                           0) \
-     - ((len) > 2 ? ((buf)[(len)-2] == '=') : 0)) \
+     - ((len) > 2 ? ((buf)[(len)-2] == '=') : 0))
     /*!< \brief Given valid base64 string `buf` of length `len`, evaluates to the exact decoded length. @hideinitializer */
 
 WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_base64_decode(
@@ -3362,10 +3362,18 @@ WOLFSENTRY_API wolfsentry_errcode_t wolfsentry_base64_decode(
     #include "wolfsentry/wolfsentry_lwip.h"
 #endif
 
+#ifdef WOLFSENTRY_NETXDUO
+    #include "wolfsentry/wolfsentry_netxduo.h"
+#endif
+
 /* conditionally include wolfsentry_util.h last -- none of the above rely on it.
  */
 #ifndef WOLFSENTRY_NO_UTIL_H
-#include <wolfsentry/wolfsentry_util.h>
+#include "wolfsentry/wolfsentry_util.h"
+#endif
+
+#ifdef WOLFSENTRY_HAVE_JSON_DOM
+#include "wolfsentry/wolfsentry_json.h"
 #endif
 
 #endif /* WOLFSENTRY_H */

--- a/wolfsentry/wolfsentry_errcodes.h
+++ b/wolfsentry/wolfsentry_errcodes.h
@@ -39,7 +39,7 @@
 #endif
 
 typedef int32_t wolfsentry_errcode_t; /*!< \brief The structured result code type for wolfSentry.  It encodes a failure or success code, a source code file ID, and a line number. */
-#ifdef FREERTOS
+#if defined(FREERTOS) || defined(THREADX)
 #define WOLFSENTRY_ERRCODE_FMT "%d"
 #elif defined(PRId32)
 #define WOLFSENTRY_ERRCODE_FMT "%" PRId32
@@ -143,7 +143,7 @@ static inline int WOLFSENTRY_ERROR_DECODE_LINE_NUMBER(wolfsentry_errcode_t x) {
 
 #define WOLFSENTRY_ERROR_ENCODE(name) WOLFSENTRY_ERROR_ENCODE_0(WOLFSENTRY_ERROR_ID_ ## name)
     /*!< \brief Compute a `wolfsentry_errcode_t` encoding the current source ID and line number, and the designated short-form error `name` (e.g. `INVALID_ARG`). @hideinitializer */
-#define WOLFSENTRY_SUCCESS_ENCODE(x) WOLFSENTRY_ERROR_ENCODE_0(WOLFSENTRY_SUCCESS_ID_ ## x)
+#define WOLFSENTRY_SUCCESS_ENCODE(name) WOLFSENTRY_ERROR_ENCODE_0(WOLFSENTRY_SUCCESS_ID_ ## name)
     /*!< \brief Compute a `wolfsentry_errcode_t` encoding the current source ID and line number, and the designated short-form success `name` (e.g. `OK`). @hideinitializer */
 
 #ifdef WOLFSENTRY_FOR_DOXYGEN
@@ -337,7 +337,9 @@ WOLFSENTRY_API const char *wolfsentry_errcode_error_name(wolfsentry_errcode_t e)
 
 #if !defined(WOLFSENTRY_NO_STDIO_STREAMS) && !defined(WOLFSENTRY_NO_DIAG_MSGS)
 
+#ifndef WOLFSENTRY_NETXDUO /* netxduo has its own errno.h */
 #include <errno.h>
+#endif
 
 #ifdef __STRICT_ANSI__
 #define WOLFSENTRY_WARN(fmt,...) WOLFSENTRY_PRINTF_ERR("%s@L%d " fmt, __FILE__, __LINE__, __VA_ARGS__)

--- a/wolfsentry/wolfsentry_netxduo.h
+++ b/wolfsentry/wolfsentry_netxduo.h
@@ -1,0 +1,70 @@
+/*
+ * wolfsentry/wolfsentry_netxduo.h
+ *
+ * Copyright (C) 2021-2025 wolfSSL Inc.
+ *
+ * This file is part of wolfSentry.
+ *
+ * wolfSentry is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSentry is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef _WOLFSENTRY_NETXDUO_H
+#define _WOLFSENTRY_NETXDUO_H
+
+#ifdef NEED_THREADX_TYPES
+#include "types.h"
+#endif
+#include "nx_api.h"
+
+#ifndef AF_INET
+#define AF_INET  2 /* IPv4 socket (UDP, TCP, etc) */
+#endif
+#ifndef AF_INET6
+#define AF_INET6 3 /* IPv6 socket (UDP, TCP, etc) */
+#endif
+
+#ifndef IPPROTO_TCP
+#define IPPROTO_TCP 6  /* TCP Socket */
+#endif
+#ifndef IPPROTO_UDP
+#define IPPROTO_UDP 17 /* TCP Socket */
+#endif
+#ifndef IPPROTO_ICMP
+#define IPPROTO_ICMP  1
+#endif
+
+#ifndef in_addr
+struct nx_bsd_in_addr {
+    ULONG           s_addr; /* Internet address (32 bits) */
+};
+#define in_addr nx_bsd_in_addr
+#endif
+
+#ifndef in6_addr
+struct nx_bsd_in6_addr {
+    union {
+        UCHAR _S6_u8[16];
+        ULONG _S6_u32[4];
+    } _S6_un;
+};
+#define in6_addr nx_bsd_in6_addr
+#endif
+
+#ifndef socklen_t
+typedef ULONG nx_bsd_socklen_t;
+#define socklen_t nx_bsd_socklen_t
+#endif
+
+#endif /* _WOLFSENTRY_NETXDUO_H */


### PR DESCRIPTION
Testing using:

```
make ^
    CC=d:/mingw/rx/4.8.2a/bin/gcc ^
    AR=d:/mingw/rx/4.8.2a/bin/ar ^
    STATIC=1 ^
    OPTIM=-O2 ^
    RUNTIME=ThreadX-NetXDuo ^
    THREADX_TOP=../../../../bsp/xlogic/rx72n/ ^
    NEED_THREADX_TYPES=1 ^
    THREADX_TYPES_TOP=../../../../bsp/src/common ^
    NETXDUO_TOP=../../../../bsp/src/ethernet ^
    EXTRA_CFLAGS="-Bd:\mingw\rx\4.8.2a\bin -gstabs -g3 -std=gnu99 -mbig-endian-data -fno-leading-underscore -ftabstop=4 -fno-common -fno-use-linker-plugin -fno-leading-underscore -fstrict-volatile-bitfields -D_REENT_SMALL -DWOLFSENTRY_NO_GNU_ATOMICS -DWOLFSENTRY_NO_STDIO_STREAMS -DWOLFSENTRY_SINGLETHREADED -DWOLFSENTRY_NO_JSON -DWOLFSENTRY_NO_JSON_DOM" ^
    C_WARNFLAGS="-Wdeclaration-after-statement -Wmissing-prototypes -Wnested-externs -Wredundant-decls -Wshadow -Wstrict-prototypes -Wundef -Wno-format -Wno-main -Wno-maybe-uninitialized -Wno-parentheses -Wno-strict-aliasing" ^
    V=1
```