### PR TITLE
20250903-wolfsentry_inet4_ntoa-BUFFER_TOO_SMALL

### DIFF
--- a/src/routes.c
+++ b/src/routes.c
@@ -3751,7 +3751,7 @@ WOLFSENTRY_API int wolfsentry_inet4_ntoa(const byte *addr, unsigned int addr_bit
         *buflen -= buflen2;
         if (i < 3) {
             if (*buflen < 2)
-                WOLFSENTRY_RETURN_OK;
+                WOLFSENTRY_ERROR_RETURN(BUFFER_TOO_SMALL);
             *buf++ = '.';
             --*buflen;
         }


### PR DESCRIPTION
`src/routes.c`: fix a wrong retval in `wolfsentry_inet4_ntoa()`.

note with amusement: I didn't catch this, Grok 4 Expert didn't catch this, and code review didn't catch it, and yet it's super-obvious!
