### PR TITLE
feat: add sbom Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -547,6 +547,58 @@ doc: doc-html $(BUILD_TOP)/doc/pdf/refman.pdf
 
 doc-clean: doc-html-clean doc-pdf-clean
 
+# SBOM generation (CRA compliance)
+SBOM_VERSION := $(shell awk '/^#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' \
+    '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
+SBOM_CDX     = wolfsentry-$(SBOM_VERSION).cdx.json
+SBOM_SPDX    = wolfsentry-$(SBOM_VERSION).spdx.json
+SBOM_SPDX_TV = wolfsentry-$(SBOM_VERSION).spdx
+
+.PHONY: sbom
+
+sbom:
+	$(Q)if [ -z "$(SBOM_VERSION)" ] || [ "$(SBOM_VERSION)" = ".." ]; then \
+	    echo "ERROR: could not extract version from wolfsentry/wolfsentry.h" 1>&2; \
+	    exit 1; \
+	fi
+	$(Q)if [ -n "$(GEN_SBOM)" ]; then \
+	    _gen_sbom="$(GEN_SBOM)"; \
+	elif [ -n "$(WOLFSSL_DIR)" ]; then \
+	    _gen_sbom="$(WOLFSSL_DIR)/scripts/gen-sbom"; \
+	else \
+	    echo "ERROR: set WOLFSSL_DIR (path to wolfssl repo) or GEN_SBOM (path to gen-sbom script)" 1>&2; \
+	    exit 1; \
+	fi; \
+	if [ ! -f "$$_gen_sbom" ]; then \
+	    echo "ERROR: gen-sbom not found: $$_gen_sbom" 1>&2; \
+	    exit 1; \
+	fi; \
+	if ! command -v python3 >/dev/null 2>&1; then \
+	    echo "ERROR: python3 not found in PATH" 1>&2; \
+	    exit 1; \
+	fi; \
+	_defines_h=$$(mktemp "$${TMPDIR:-/tmp}/wolfsentry-defines.XXXXXX"); \
+	trap 'rm -f "$$_defines_h"' EXIT; \
+	if ! $(CC) -dM -E -I'$(SRC_TOP)' -x c /dev/null >"$$_defines_h" 2>/dev/null; then \
+	    echo "ERROR: $(CC) -dM -E failed" 1>&2; \
+	    exit 1; \
+	fi; \
+	_srcs=""; \
+	for _f in $(SRCS); do _srcs="$$_srcs $(SRC_TOP)/src/$$_f"; done; \
+	python3 "$$_gen_sbom" \
+	    --name wolfsentry \
+	    --version "$(SBOM_VERSION)" \
+	    --supplier "wolfSSL Inc." \
+	    --license-file "$(SRC_TOP)/LICENSING" \
+	    --options-h "$$_defines_h" \
+	    --srcs $$_srcs \
+	    --cdx-out "$(BUILD_TOP)/$(SBOM_CDX)" \
+	    --spdx-out "$(BUILD_TOP)/$(SBOM_SPDX)"
+ifndef VERY_QUIET
+	$(Q)echo "SBOM written: $(BUILD_TOP)/$(SBOM_CDX)"
+	$(Q)echo "              $(BUILD_TOP)/$(SBOM_SPDX)"
+endif
+
 .PHONY: clean
 clean:
 	$(Q)rm $(CLEAN_RM_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,7 @@ doc: doc-html $(BUILD_TOP)/doc/pdf/refman.pdf
 doc-clean: doc-html-clean doc-pdf-clean
 
 # SBOM generation (CRA compliance)
-SBOM_VERSION := $(shell awk '/^#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
+SBOM_VERSION := $(shell awk '/^\#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^\#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^\#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
 SBOM_CDX     = wolfsentry-$(SBOM_VERSION).cdx.json
 SBOM_SPDX    = wolfsentry-$(SBOM_VERSION).spdx.json
 SBOM_SPDX_TV = wolfsentry-$(SBOM_VERSION).spdx

--- a/Makefile
+++ b/Makefile
@@ -548,8 +548,7 @@ doc: doc-html $(BUILD_TOP)/doc/pdf/refman.pdf
 doc-clean: doc-html-clean doc-pdf-clean
 
 # SBOM generation (CRA compliance)
-SBOM_VERSION := $(shell awk '/^#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' \
-    '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
+SBOM_VERSION := $(shell awk '/^#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
 SBOM_CDX     = wolfsentry-$(SBOM_VERSION).cdx.json
 SBOM_SPDX    = wolfsentry-$(SBOM_VERSION).spdx.json
 SBOM_SPDX_TV = wolfsentry-$(SBOM_VERSION).spdx

--- a/Makefile
+++ b/Makefile
@@ -551,13 +551,12 @@ doc-clean: doc-html-clean doc-pdf-clean
 SBOM_VERSION := $(shell awk '/^\#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^\#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^\#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
 SBOM_CDX     = wolfsentry-$(SBOM_VERSION).cdx.json
 SBOM_SPDX    = wolfsentry-$(SBOM_VERSION).spdx.json
-SBOM_SPDX_TV = wolfsentry-$(SBOM_VERSION).spdx
 
 .PHONY: sbom
 
 sbom:
-	$(Q)if [ -z "$(SBOM_VERSION)" ] || [ "$(SBOM_VERSION)" = ".." ]; then \
-	    echo "ERROR: could not extract version from wolfsentry/wolfsentry.h" 1>&2; \
+	$(Q)if ! printf '%s' "$(SBOM_VERSION)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+	    echo "ERROR: could not extract a valid version (got '$(SBOM_VERSION)') from wolfsentry/wolfsentry.h" 1>&2; \
 	    exit 1; \
 	fi
 	$(Q)if [ -n "$(GEN_SBOM)" ]; then \
@@ -578,12 +577,13 @@ sbom:
 	fi; \
 	_defines_h=$$(mktemp "$${TMPDIR:-/tmp}/wolfsentry-defines.XXXXXX"); \
 	trap 'rm -f "$$_defines_h"' EXIT; \
-	if ! $(CC) -dM -E -I'$(SRC_TOP)' -x c /dev/null >"$$_defines_h" 2>/dev/null; then \
+	if ! $(CC) $(CPPFLAGS) $(CFLAGS) -dM -E -x c /dev/null >"$$_defines_h" 2>/dev/null; then \
 	    echo "ERROR: $(CC) -dM -E failed" 1>&2; \
 	    exit 1; \
 	fi; \
 	_srcs=""; \
 	for _f in $(SRCS); do _srcs="$$_srcs $(SRC_TOP)/src/$$_f"; done; \
+	mkdir -p "$(BUILD_TOP)"; \
 	python3 "$$_gen_sbom" \
 	    --name wolfsentry \
 	    --version "$(SBOM_VERSION)" \

--- a/Makefile
+++ b/Makefile
@@ -548,13 +548,24 @@ doc: doc-html $(BUILD_TOP)/doc/pdf/refman.pdf
 doc-clean: doc-html-clean doc-pdf-clean
 
 # SBOM generation (CRA compliance)
-SBOM_VERSION := $(shell awk '/^\#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^\#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^\#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
+SBOM_VERSION := $(shell $(AWK) '/^\#define WOLFSENTRY_VERSION_MAJOR/{maj=$$3} /^\#define WOLFSENTRY_VERSION_MINOR/{min=$$3} /^\#define WOLFSENTRY_VERSION_TINY/{tiny=$$3} END{print maj"."min"."tiny}' '$(SRC_TOP)/wolfsentry/wolfsentry.h' 2>/dev/null)
 SBOM_CDX     = wolfsentry-$(SBOM_VERSION).cdx.json
 SBOM_SPDX    = wolfsentry-$(SBOM_VERSION).spdx.json
 
 .PHONY: sbom
 
-sbom:
+# The effective build configuration comes from $(OPTIONS_FILE): either the
+# generated $(BUILD_TOP)/wolfsentry/wolfsentry_options.h (distilled from the
+# real CFLAGS by build_wolfsentry_options_h.awk) or, under USER_SETTINGS_FILE,
+# the user's own settings header, which gen-sbom parses with --user-settings
+# since it is not a flat define dump.
+ifdef USER_SETTINGS_FILE
+    SBOM_OPTIONS_ARG = --user-settings "$(OPTIONS_FILE)"
+else
+    SBOM_OPTIONS_ARG = --options-h "$(OPTIONS_FILE)"
+endif
+
+sbom: $(OPTIONS_FILE)
 	$(Q)if ! printf '%s' "$(SBOM_VERSION)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
 	    echo "ERROR: could not extract a valid version (got '$(SBOM_VERSION)') from wolfsentry/wolfsentry.h" 1>&2; \
 	    exit 1; \
@@ -575,12 +586,6 @@ sbom:
 	    echo "ERROR: python3 not found in PATH" 1>&2; \
 	    exit 1; \
 	fi; \
-	_defines_h=$$(mktemp "$${TMPDIR:-/tmp}/wolfsentry-defines.XXXXXX"); \
-	trap 'rm -f "$$_defines_h"' EXIT; \
-	if ! $(CC) $(CPPFLAGS) $(CFLAGS) -dM -E -x c /dev/null >"$$_defines_h" 2>/dev/null; then \
-	    echo "ERROR: $(CC) -dM -E failed" 1>&2; \
-	    exit 1; \
-	fi; \
 	_srcs=""; \
 	for _f in $(SRCS); do _srcs="$$_srcs $(SRC_TOP)/src/$$_f"; done; \
 	mkdir -p "$(BUILD_TOP)"; \
@@ -589,7 +594,7 @@ sbom:
 	    --version "$(SBOM_VERSION)" \
 	    --supplier "wolfSSL Inc." \
 	    --license-file "$(SRC_TOP)/LICENSING" \
-	    --options-h "$$_defines_h" \
+	    $(SBOM_OPTIONS_ARG) \
 	    --srcs $$_srcs \
 	    --cdx-out "$(BUILD_TOP)/$(SBOM_CDX)" \
 	    --spdx-out "$(BUILD_TOP)/$(SBOM_SPDX)"
@@ -597,6 +602,20 @@ ifndef VERY_QUIET
 	$(Q)echo "SBOM written: $(BUILD_TOP)/$(SBOM_CDX)"
 	$(Q)echo "              $(BUILD_TOP)/$(SBOM_SPDX)"
 endif
+
+ifndef INSTALL_DOCDIR
+    INSTALL_DOCDIR := $(INSTALL_DIR)/share/doc/wolfsentry
+endif
+
+.PHONY: install-sbom
+install-sbom: sbom
+	$(Q)mkdir -p $(INSTALL_DOCDIR)
+	install -p -m 0644 $(BUILD_TOP)/$(SBOM_CDX) $(BUILD_TOP)/$(SBOM_SPDX) $(INSTALL_DOCDIR)
+
+.PHONY: uninstall-sbom
+uninstall-sbom:
+	$(RM) $(INSTALL_DOCDIR)/$(SBOM_CDX) $(INSTALL_DOCDIR)/$(SBOM_SPDX)
+	@rmdir $(INSTALL_DOCDIR) 2>/dev/null || exit 0
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -219,3 +219,25 @@ build with wolfSentry integration, and use `--with-wolfsentry=/the/install/path`
 if wolfSentry is installed in a nonstandard location.  The wolfSSL test
 client/server can be loaded with user-supplied wolfSentry JSON configurations
 from the command line, using `--wolfsentry-config <file>`.
+
+## SBOM / EU CRA Compliance
+
+wolfSentry generates a Software Bill of Materials (SBOM) in CycloneDX 1.6 and
+SPDX 2.3 formats to support compliance with the EU Cyber Resilience Act (CRA).
+
+```sh
+make sbom WOLFSSL_DIR=/path/to/wolfssl
+```
+
+Requires `python3` and `pyspdxtools` (`pip install spdx-tools`). `WOLFSSL_DIR`
+must point to a wolfssl source tree containing `scripts/gen-sbom` (branch
+`feat/sbom-embedded`, or `master` once wolfSSL/wolfssl#10343 merges).
+
+Output: `wolfsentry-<version>.cdx.json`, `wolfsentry-<version>.spdx.json`, `wolfsentry-<version>.spdx`
+
+```sh
+make install-sbom    # installs to $(datadir)/doc/wolfsentry/
+make uninstall-sbom
+```
+
+For further CRA guidance see [wolfssl/doc/CRA.md](https://github.com/wolfSSL/wolfssl/blob/master/doc/CRA.md).

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ must point to a wolfssl source tree containing `scripts/gen-sbom` (branch
 Output: `wolfsentry-<version>.cdx.json`, `wolfsentry-<version>.spdx.json`, `wolfsentry-<version>.spdx`
 
 ```sh
-make install-sbom    # installs to $(datadir)/doc/wolfsentry/
+make install-sbom    # installs to $(INSTALL_DOCDIR), default /usr/local/share/doc/wolfsentry/
 make uninstall-sbom
 ```
 


### PR DESCRIPTION
## Summary

Adds a `make sbom` target that produces CycloneDX and SPDX SBOM files for wolfsentry.

- Extracts version from `WOLFSENTRY_VERSION_MAJOR`/`MINOR`/`TINY` macros in `wolfsentry/wolfsentry.h`
- Enumerates sources from `src/*.c` (sorted)
- Hashes each source file
- Calls `gen-sbom` (located via `GEN_SBOM` or `WOLFSSL_DIR/scripts/gen-sbom`)
- wolfsentry is standalone (no wolfssl dependency), so `WOLFSSL_DIR` is only needed to locate gen-sbom

## Usage

\`\`\`sh
# With WOLFSSL_DIR (points gen-sbom location):
make sbom WOLFSSL_DIR=/path/to/wolfssl/source

# Or with explicit gen-sbom path:
make sbom GEN_SBOM=/path/to/wolfssl/scripts/gen-sbom
\`\`\`

Outputs: `wolfsentry-<version>.cdx.json`, `wolfsentry-<version>.spdx.json`

## Requirements

- `gen-sbom` from a wolfssl tree containing `scripts/gen-sbom` (available on the `feat/sbom-embedded` branch of wolfssl)
- `python3` on the build host

## Test plan
- [ ] `make sbom WOLFSSL_DIR=...`
- [ ] Verify CDX and SPDX output files are produced